### PR TITLE
feat: display cumulative price breakdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,11 @@ export {
   computeQuantities,
   extractPricingEntitiesBySlug,
 } from './pricing';
-export { getDisplayTierByQuantity, getDisplayTiersByQuantity, getTierDescription } from './tiers';
+export {
+  computeCumulativeValue,
+  getDisplayTierByQuantity,
+  getDisplayTiersByQuantity,
+  getTierDescription,
+} from './tiers';
 export type { PriceTierDisplayMode, PricingDetails, Tax, TaxAmountBreakdown, TimeFrequency } from './types';
 export { isTaxInclusivePrice } from './utils';

--- a/src/tiers/index.test.ts
+++ b/src/tiers/index.test.ts
@@ -18,10 +18,11 @@ const baseTiers: PriceTier[] = [
 const mockTranslations = {
   ['selectvalues.Price.unit.kWh' as string]: 'kWh',
   ['selectvalues.Price.unit.unit' as string]: 'unit',
+  ['selectvalues.Price.unit.m' as string]: 'm',
   ['starts_at' as string]: 'Starts at',
 };
 
-const t = jest.fn().mockImplementation((key: string) => mockTranslations[key] || key);
+const t = jest.fn().mockImplementation((key: string, { defaultValue }) => mockTranslations[key] ?? defaultValue ?? key);
 
 describe('getDisplayTierByQuantity', () => {
   it.each`
@@ -225,16 +226,16 @@ describe('getTierDescription', () => {
 
 describe('computeCumulativeValue', () => {
   it.each`
-    quantityToSelectTier | expected
-    ${1}                 | ${{ total: '€10.00', average: '€10.00/kWh', breakdown: [{ quantityUsed: '1 kWh', tierAmountDecimal: '€10.00', totalAmountDecimal: '€10.00' }] }}
-    ${2}                 | ${{ total: '€20.00', average: '€10.00/kWh', breakdown: [{ quantityUsed: '2 kWh', tierAmountDecimal: '€10.00', totalAmountDecimal: '€20.00' }] }}
-    ${5}                 | ${{ total: '€50.00', average: '€10.00/kWh', breakdown: [{ quantityUsed: '5 kWh', tierAmountDecimal: '€10.00', totalAmountDecimal: '€50.00' }] }}
-    ${15}                | ${{ total: '€145.00', average: '€9.67/kWh', breakdown: [{ quantityUsed: '10 kWh', tierAmountDecimal: '€10.00', totalAmountDecimal: '€100.00' }, { quantityUsed: '5 kWh', tierAmountDecimal: '€9.00', totalAmountDecimal: '€45.00' }] }}
-    ${30}                | ${{ total: '€270.00', average: '€9.00/kWh', breakdown: [{ quantityUsed: '10 kWh', tierAmountDecimal: '€10.00', totalAmountDecimal: '€100.00' }, { quantityUsed: '10 kWh', tierAmountDecimal: '€9.00', totalAmountDecimal: '€90.00' }, { quantityUsed: '10 kWh', tierAmountDecimal: '€8.00', totalAmountDecimal: '€80.00' }] }}
+    quantityToSelectTier | unit        | locale       | currency | expected
+    ${1}                 | ${'kWh'}    | ${undefined} | ${'EUR'} | ${{ total: '10,00\xa0€', average: '10,00\xa0€/kWh', breakdown: [{ quantityUsed: '1 kWh', tierAmountDecimal: '10,00\xa0€', totalAmountDecimal: '10,00\xa0€' }] }}
+    ${2}                 | ${'m'}      | ${'de'}      | ${'EUR'} | ${{ total: '20,00\xa0€', average: '10,00\xa0€/m', breakdown: [{ quantityUsed: '2 m', tierAmountDecimal: '10,00\xa0€', totalAmountDecimal: '20,00\xa0€' }] }}
+    ${5}                 | ${'kWh'}    | ${'en'}      | ${'EUR'} | ${{ total: '€50.00', average: '€10.00/kWh', breakdown: [{ quantityUsed: '5 kWh', tierAmountDecimal: '€10.00', totalAmountDecimal: '€50.00' }] }}
+    ${15}                | ${'banana'} | ${'en'}      | ${'EUR'} | ${{ total: '€145.00', average: '€9.67/banana', breakdown: [{ quantityUsed: '10 banana', tierAmountDecimal: '€10.00', totalAmountDecimal: '€100.00' }, { quantityUsed: '5 banana', tierAmountDecimal: '€9.00', totalAmountDecimal: '€45.00' }] }}
+    ${30}                | ${'kWh'}    | ${'en'}      | ${'USD'} | ${{ total: '$270.00', average: '$9.00/kWh', breakdown: [{ quantityUsed: '10 kWh', tierAmountDecimal: '$10.00', totalAmountDecimal: '$100.00' }, { quantityUsed: '10 kWh', tierAmountDecimal: '$9.00', totalAmountDecimal: '$90.00' }, { quantityUsed: '10 kWh', tierAmountDecimal: '$8.00', totalAmountDecimal: '$80.00' }] }}
   `(
     'should compute cumulative value correctly when quantityToSelectTier=$quantityToSelectTier',
-    ({ quantityToSelectTier, expected }) => {
-      expect(computeCumulativeValue(baseTiers, quantityToSelectTier, 'kWh', 'en', 'EUR', t)).toEqual(expected);
+    ({ quantityToSelectTier, unit, locale, currency, expected }) => {
+      expect(computeCumulativeValue(baseTiers, quantityToSelectTier, unit, locale, currency, t)).toEqual(expected);
     },
   );
 });

--- a/src/tiers/index.ts
+++ b/src/tiers/index.ts
@@ -1,7 +1,7 @@
 import { Currency, Dinero } from 'dinero.js';
 
 import { DEFAULT_CURRENCY } from '../currencies';
-import { formatAmountFromString, toDinero } from '../formatters';
+import { DEFAULT_LOCALE, formatAmountFromString, toDinero } from '../formatters';
 import { PricingModel } from '../pricing';
 import { Price, PriceTier } from '../types';
 import { getQuantityForTier } from '../utils';
@@ -177,10 +177,11 @@ export const computeCumulativeValue = (
   const priceTiersForQuantity = getDisplayTiersByQuantity(tiers, quantityToSelectTier, PricingModel.tieredGraduated);
   const formattedUnit = t(`selectvalues.Price.unit.${unit || 'unit'}`, {
     ns: 'entity',
+    defaultValue: unit,
   });
   const formatOptions = {
     currency: currency || DEFAULT_CURRENCY,
-    locale,
+    locale: locale || DEFAULT_LOCALE,
     useRealPrecision: true,
     enableSubunitDisplay: true,
   };

--- a/src/tiers/index.ts
+++ b/src/tiers/index.ts
@@ -1,12 +1,19 @@
-import { Currency } from 'dinero.js';
+import { Currency, Dinero } from 'dinero.js';
 
 import { DEFAULT_CURRENCY } from '../currencies';
-import { formatAmountFromString } from '../formatters';
+import { formatAmountFromString, toDinero } from '../formatters';
 import { PricingModel } from '../pricing';
 import { Price, PriceTier } from '../types';
+import { getQuantityForTier } from '../utils';
 
 const byInputQuantity = (tiers: PriceTier[], quantity: number) => (_: PriceTier, index: number) =>
   Math.ceil(quantity) > (tiers[index - 1]?.up_to || 0);
+
+type CumulativePriceBreakdownItem = {
+  quantityUsed: string;
+  tierAmountDecimal: string;
+  totalAmountDecimal: string;
+};
 
 /**
  * This function returns the price tier that matches the input quantity.
@@ -154,3 +161,62 @@ export function getTierDescription(
     (formatedFlatFeeString || '')
   );
 }
+
+export const computeCumulativeValue = (
+  tiers: PriceTier[] | undefined,
+  quantityToSelectTier: number,
+  unit: string | undefined,
+  locale: string,
+  currency: Currency | undefined,
+  t: (key: string, options?: { ns: string; defaultValue?: string }) => string,
+) => {
+  if (!tiers || !tiers.length || quantityToSelectTier <= 0) {
+    return;
+  }
+
+  const priceTiersForQuantity = getDisplayTiersByQuantity(tiers, quantityToSelectTier, PricingModel.tieredGraduated);
+  const formattedUnit = t(`selectvalues.Price.unit.${unit || 'unit'}`, {
+    ns: 'entity',
+  });
+  const formatOptions = {
+    currency: currency || DEFAULT_CURRENCY,
+    locale,
+    useRealPrecision: true,
+    enableSubunitDisplay: true,
+  };
+
+  const breakdown: CumulativePriceBreakdownItem[] = [];
+
+  const total = priceTiersForQuantity.reduce((total: Dinero, tier: PriceTier, index: number) => {
+    const tierMinQuantity = index === 0 ? 0 : tiers[index - 1].up_to;
+    const tierMaxQuantity = tier.up_to || Infinity;
+    const graduatedQuantity = getQuantityForTier(tierMinQuantity, tierMaxQuantity, quantityToSelectTier);
+    const tierAmount = toDinero(tier.unit_amount_decimal).multiply(graduatedQuantity);
+
+    breakdown.push({
+      quantityUsed: `${graduatedQuantity} ${formattedUnit}`,
+      tierAmountDecimal: formatAmountFromString({
+        decimalAmount: tier.unit_amount_decimal,
+        ...formatOptions,
+      }),
+      totalAmountDecimal: formatAmountFromString({
+        decimalAmount: tierAmount.toFormat('0.00'),
+        ...formatOptions,
+      }),
+    });
+
+    return tierAmount.add(total);
+  }, toDinero('0'));
+
+  return {
+    total: formatAmountFromString({
+      decimalAmount: total.toFormat('0.00'),
+      ...formatOptions,
+    }),
+    average: `${formatAmountFromString({
+      decimalAmount: total.divide(quantityToSelectTier).toFormat('0.00'),
+      ...formatOptions,
+    })}/${formattedUnit}`,
+    breakdown,
+  };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -111,7 +111,7 @@ const byPriceTiersForQuantity = (tiers: PriceTier[], quantity: number) => (_: Pr
  * @param {number} quantity - The quantity.
  * @return {PriceTier[]} - The result price tiers.
  */
-const getPriceTiersForQuantity = (tiers: PriceTier[], quantity: number): PriceTier[] => {
+export const getPriceTiersForQuantity = (tiers: PriceTier[], quantity: number): PriceTier[] => {
   const selectedTiers = tiers?.filter(byPriceTiersForQuantity(tiers, quantity));
 
   if (selectedTiers?.length) {


### PR DESCRIPTION
<img width="645" alt="image" src="https://github.com/epilot-dev/pricing/assets/36714557/d8fdaa72-19ae-463d-95b7-48dd65f25dc6">

Will be used for the breakdown on the journey shopping cart, order table and order export 

<img width="712" alt="image" src="https://github.com/epilot-dev/pricing/assets/36714557/43f95304-b2ce-47cf-95ff-54b709cd8318">
