### PR TITLE
Include unit_amount_gross in pricing computations

### DIFF
--- a/src/__tests__/fixtures/pricing.results.ts
+++ b/src/__tests__/fixtures/pricing.results.ts
@@ -218,6 +218,7 @@ export const computedCompositePrice: CompositePriceItem & { [key: string]: unkno
       unit_amount: 10690000000000,
       unit_amount_decimal: '10.69',
       unit_amount_net: 9718181818182,
+      unit_amount_gross: 10690000000000,
       pricing_model: 'per_unit',
     },
     {
@@ -290,6 +291,7 @@ export const computedCompositePrice: CompositePriceItem & { [key: string]: unkno
       ],
       unit_amount: 450000000000,
       unit_amount_decimal: '0.45',
+      unit_amount_gross: 450000000000,
       unit_amount_net: 424528301887,
       pricing_model: 'per_unit',
     },
@@ -333,6 +335,7 @@ export const computedCompositePrice: CompositePriceItem & { [key: string]: unkno
       },
       _product: {},
       amount_subtotal: 420168067226891,
+      unit_amount_gross: 500000000000000,
       amount_total: 500000000000000,
       type: 'one_time',
       currency: 'EUR',
@@ -1438,6 +1441,7 @@ export const compositePricesUnitAmountZeroResult = {
           type: 'recurring',
           unit_amount: 1069,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
           unit_amount_net: 972,
           pricing_model: 'per_unit',
         },
@@ -1511,6 +1515,7 @@ export const compositePricesUnitAmountZeroResult = {
           type: 'recurring',
           unit_amount: 0,
           unit_amount_decimal: '0.00',
+          unit_amount_gross: 0,
           unit_amount_net: 0,
           pricing_model: 'per_unit',
         },
@@ -1522,7 +1527,14 @@ export const compositePricesUnitAmountZeroResult = {
         amount_tax: 97,
         breakdown: {
           recurrences: [
-            { amount_subtotal: 972, amount_tax: 97, amount_total: 1069, billing_period: 'monthly', type: 'recurring' },
+            {
+              amount_subtotal: 972,
+              amount_tax: 97,
+              amount_total: 1069,
+              unit_amount_gross: 1069,
+              billing_period: 'monthly',
+              type: 'recurring',
+            },
           ],
           taxes: [
             { amount: 97, tax: { _id: '10', rate: 10, type: 'VAT' } },
@@ -1530,13 +1542,21 @@ export const compositePricesUnitAmountZeroResult = {
           ],
         },
       },
+      unit_amount_gross: 1069,
     },
   ],
   total_details: {
     amount_tax: 97,
     breakdown: {
       recurrences: [
-        { amount_subtotal: 972, amount_tax: 97, amount_total: 1069, billing_period: 'monthly', type: 'recurring' },
+        {
+          amount_subtotal: 972,
+          amount_tax: 97,
+          amount_total: 1069,
+          unit_amount_gross: 1069,
+          billing_period: 'monthly',
+          type: 'recurring',
+        },
       ],
       taxes: [
         { amount: 97, tax: { _id: '10', rate: 10, type: 'VAT' } },
@@ -1544,6 +1564,7 @@ export const compositePricesUnitAmountZeroResult = {
       ],
     },
   },
+  unit_amount_gross: 1069,
 };
 
 export const priceWithDisplayOnRequest = {
@@ -1641,6 +1662,7 @@ export const priceWithDisplayOnRequestAndSimplePrices = {
       unit_amount: 78946,
       unit_amount_net: 66341,
       unit_amount_decimal: '789.456224456678',
+      unit_amount_gross: 78946,
     },
     {
       ...priceItem2,
@@ -1669,6 +1691,7 @@ export const priceWithDisplayOnRequestAndSimplePrices = {
       unit_amount: 3446,
       unit_amount_net: 2895,
       unit_amount_decimal: '34.456224456678',
+      unit_amount_gross: 3446,
     },
     {
       ...priceItem3,
@@ -1697,6 +1720,7 @@ export const priceWithDisplayOnRequestAndSimplePrices = {
       unit_amount: 4546,
       unit_amount_net: 4546,
       unit_amount_decimal: '45.456224456678',
+      unit_amount_gross: 4818,
     },
     {
       ...priceItem6,
@@ -1710,6 +1734,7 @@ export const priceWithDisplayOnRequestAndSimplePrices = {
       unit_amount: 4546,
       unit_amount_net: 4546,
       unit_amount_decimal: '45.456224456678',
+      unit_amount_gross: 5000,
     },
     {
       _price: {
@@ -1759,6 +1784,7 @@ export const priceWithDisplayOnRequestAndSimplePrices = {
       unit_amount: 4546,
       unit_amount_net: 4546,
       unit_amount_decimal: '45.456224456678',
+      unit_amount_gross: 5000,
       pricing_model: 'per_unit',
     },
   ],
@@ -1796,6 +1822,7 @@ export const priceWithDisplayOnRequestAndSimplePrices = {
           amount_subtotal: 331704,
           amount_total: 394728,
           amount_tax: 63024,
+          unit_amount_gross: 78946,
           type: 'one_time',
         },
         {
@@ -1804,6 +1831,7 @@ export const priceWithDisplayOnRequestAndSimplePrices = {
           billing_period: 'monthly',
           amount_tax: 550,
           type: 'recurring',
+          unit_amount_gross: 3446,
         },
         {
           amount_subtotal: 27274,
@@ -1811,10 +1839,12 @@ export const priceWithDisplayOnRequestAndSimplePrices = {
           amount_tax: 2182,
           billing_period: 'yearly',
           type: 'recurring',
+          unit_amount_gross: 9819,
         },
       ],
     },
   },
+  unit_amount_gross: 92210,
 };
 
 export const compositePriceWithDisplayOnRequest = {
@@ -1972,6 +2002,7 @@ export const compositePriceWithDisplayOnRequest = {
           unit_amount: 1069,
           unit_amount_net: 972,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
           amount_subtotal: 972,
           amount_total: 1069,
           pricing_model: 'per_unit',
@@ -2039,6 +2070,7 @@ export const compositePriceWithDisplayOnRequest = {
           unit_amount: 1069,
           unit_amount_net: 972,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
           amount_subtotal: 972,
           amount_total: 1069,
           pricing_model: 'per_unit',
@@ -2052,6 +2084,7 @@ export const compositePriceWithDisplayOnRequest = {
           taxes: [] as any,
         },
       },
+      unit_amount_gross: 0,
     },
   ],
   amount_subtotal: 0,
@@ -2064,6 +2097,7 @@ export const compositePriceWithDisplayOnRequest = {
       recurrences: [] as any,
     },
   },
+  unit_amount_gross: 0,
 };
 
 export const compositePriceWithDisplayOnRequestAndOthers = {
@@ -2119,6 +2153,7 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
       unit_amount: 78946,
       unit_amount_net: 66341,
       unit_amount_decimal: '789.456224456678',
+      unit_amount_gross: 78946,
       amount_subtotal: 331704,
       amount_total: 394728,
       pricing_model: 'per_unit',
@@ -2167,6 +2202,7 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
       unit_amount: 3446,
       unit_amount_net: 2895,
       unit_amount_decimal: '34.456224456678',
+      unit_amount_gross: 3446,
       amount_subtotal: 2895,
       amount_total: 3446,
       taxes: [
@@ -2247,6 +2283,7 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
       unit_amount: 4546,
       unit_amount_net: 4546,
       unit_amount_decimal: '45.456224456678',
+      unit_amount_gross: 4818,
       amount_subtotal: 13637,
       amount_total: 14455,
       pricing_model: 'per_unit',
@@ -2276,6 +2313,7 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
         unit_amount: 78946,
         unit_amount_currency: 'EUR',
         unit_amount_decimal: '789.456224456678',
+
         type: 'one_time',
         tax: [
           {
@@ -2302,6 +2340,7 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
       unit_amount: 78946,
       unit_amount_net: 66341,
       unit_amount_decimal: '789.456224456678',
+      unit_amount_gross: 78946,
       amount_subtotal: 331704,
       amount_total: 394728,
       pricing_model: 'per_unit',
@@ -2365,6 +2404,7 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
       unit_amount: 4546,
       unit_amount_net: 4546,
       unit_amount_decimal: '45.456224456678',
+      unit_amount_gross: 4818,
       amount_subtotal: 13637,
       amount_total: 14455,
       pricing_model: 'per_unit',
@@ -2386,9 +2426,16 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
               billing_period: 'monthly',
               amount_subtotal: 1014,
               amount_total: 1114,
+              unit_amount_gross: 1114,
               amount_tax: 100,
             },
-            { type: 'one_time', amount_subtotal: 42017, amount_total: 50000, amount_tax: 7983 },
+            {
+              type: 'one_time',
+              amount_subtotal: 42017,
+              amount_total: 50000,
+              unit_amount_gross: 50000,
+              amount_tax: 7983,
+            },
           ],
         },
       },
@@ -2592,6 +2639,7 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
           unit_amount: 1069,
           unit_amount_net: 972,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
           amount_subtotal: 972,
           amount_total: 1069,
           pricing_model: 'per_unit',
@@ -2661,6 +2709,7 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
           unit_amount: 45,
           unit_amount_net: 42,
           unit_amount_decimal: '0.45',
+          unit_amount_gross: 45,
           amount_subtotal: 42,
           amount_total: 45,
           pricing_model: 'per_unit',
@@ -2729,11 +2778,13 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
           unit_amount: 50000,
           unit_amount_net: 42017,
           unit_amount_decimal: '500.00',
+          unit_amount_gross: 50000,
           amount_subtotal: 42017,
           amount_total: 50000,
           pricing_model: 'per_unit',
         },
       ],
+      unit_amount_gross: 51114,
     },
     {
       amount_subtotal: 0,
@@ -2899,6 +2950,7 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
           description: 'Base price per month',
           unit_amount: 1069,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
           unit_amount_net: 972,
           amount_subtotal: 972,
           amount_total: 1069,
@@ -2966,6 +3018,7 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
           description: 'Base price per month',
           unit_amount: 1069,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
           unit_amount_net: 972,
           amount_subtotal: 972,
           amount_total: 1069,
@@ -2980,10 +3033,12 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
           taxes: [] as Tax[],
         },
       },
+      unit_amount_gross: 0,
     },
   ],
   amount_subtotal: 736609,
   amount_total: 872926,
+
   total_details: {
     amount_tax: 136317,
     breakdown: {
@@ -2993,12 +3048,33 @@ export const compositePriceWithDisplayOnRequestAndOthers = {
         { tax: { _id: '10', type: 'VAT', rate: 10 }, amount: 97 },
       ],
       recurrences: [
-        { type: 'one_time', amount_subtotal: 705425, amount_total: 839456, amount_tax: 134031 },
-        { type: 'recurring', billing_period: 'monthly', amount_subtotal: 3910, amount_total: 4560, amount_tax: 650 },
-        { type: 'recurring', billing_period: 'yearly', amount_subtotal: 27274, amount_total: 28910, amount_tax: 1636 },
+        {
+          type: 'one_time',
+          amount_subtotal: 705425,
+          amount_total: 839456,
+          unit_amount_gross: 207891,
+          amount_tax: 134031,
+        },
+        {
+          type: 'recurring',
+          billing_period: 'monthly',
+          amount_subtotal: 3910,
+          amount_total: 4560,
+          unit_amount_gross: 4560,
+          amount_tax: 650,
+        },
+        {
+          type: 'recurring',
+          billing_period: 'yearly',
+          amount_subtotal: 27274,
+          amount_total: 28910,
+          unit_amount_gross: 9637,
+          amount_tax: 1636,
+        },
       ],
     },
   },
+  unit_amount_gross: 222088,
 };
 
 export const resultCompositePriceQuantity2 = {
@@ -3046,7 +3122,6 @@ export const resultCompositePriceQuantity2 = {
                 _schema: 'tax',
                 _title: '',
                 _updated_at: '2022-06-29T20:26:19.020Z',
-
                 rate: 10,
                 type: 'VAT',
               },
@@ -3226,6 +3301,7 @@ export const resultCompositePriceQuantity2 = {
           unit_amount: 1069,
           unit_amount_net: 972,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
           pricing_model: 'per_unit',
         },
         {
@@ -3299,6 +3375,7 @@ export const resultCompositePriceQuantity2 = {
           unit_amount: 45,
           unit_amount_net: 42,
           unit_amount_decimal: '0.45',
+          unit_amount_gross: 45,
           pricing_model: 'per_unit',
         },
         {
@@ -3367,6 +3444,7 @@ export const resultCompositePriceQuantity2 = {
           unit_amount: 50000,
           unit_amount_net: 42017,
           unit_amount_decimal: '500.00',
+          unit_amount_gross: 50000,
           pricing_model: 'per_unit',
         },
       ],
@@ -3381,10 +3459,17 @@ export const resultCompositePriceQuantity2 = {
               amount_subtotal: 2029,
               amount_tax: 199,
               amount_total: 2228,
+              unit_amount_gross: 1114,
               billing_period: 'monthly',
               type: 'recurring',
             },
-            { amount_subtotal: 84034, amount_tax: 15966, amount_total: 100000, type: 'one_time' },
+            {
+              amount_subtotal: 84034,
+              amount_tax: 15966,
+              amount_total: 100000,
+              unit_amount_gross: 50000,
+              type: 'one_time',
+            },
           ],
           taxes: [
             { amount: 194, tax: { _id: '10', rate: 10, type: 'VAT' } },
@@ -3393,14 +3478,22 @@ export const resultCompositePriceQuantity2 = {
           ],
         },
       },
+      unit_amount_gross: 51114,
     },
   ],
   total_details: {
     amount_tax: 16166,
     breakdown: {
       recurrences: [
-        { amount_subtotal: 2029, amount_tax: 199, amount_total: 2228, billing_period: 'monthly', type: 'recurring' },
-        { amount_subtotal: 84034, amount_tax: 15966, amount_total: 100000, type: 'one_time' },
+        {
+          amount_subtotal: 2029,
+          amount_tax: 199,
+          amount_total: 2228,
+          unit_amount_gross: 1114,
+          billing_period: 'monthly',
+          type: 'recurring',
+        },
+        { amount_subtotal: 84034, amount_tax: 15966, amount_total: 100000, unit_amount_gross: 50000, type: 'one_time' },
       ],
       taxes: [
         { amount: 194, tax: { _id: '10', rate: 10, type: 'VAT' } },
@@ -3409,6 +3502,7 @@ export const resultCompositePriceQuantity2 = {
       ],
     },
   },
+  unit_amount_gross: 51114,
 };
 
 export const priceDetailsForOnePrice = {
@@ -3469,6 +3563,7 @@ export const priceDetailsForOnePrice = {
       ],
       unit_amount: 78946,
       unit_amount_net: 66341,
+      unit_amount_gross: 78946,
       unit_amount_decimal: '789.456224456678',
       pricing_model: 'per_unit',
     },
@@ -3476,10 +3571,19 @@ export const priceDetailsForOnePrice = {
   total_details: {
     amount_tax: 63024,
     breakdown: {
-      recurrences: [{ amount_subtotal: 331704, amount_tax: 63024, amount_total: 394728, type: 'one_time' }],
+      recurrences: [
+        {
+          amount_subtotal: 331704,
+          amount_tax: 63024,
+          amount_total: 394728,
+          unit_amount_gross: 78946,
+          type: 'one_time',
+        },
+      ],
       taxes: [{ amount: 63024, tax: { _id: '19', rate: 19, type: 'VAT' } }],
     },
   },
+  unit_amount_gross: 78946,
 };
 
 export const priceDetailsForCompositePrice = {
@@ -3494,8 +3598,15 @@ export const priceDetailsForCompositePrice = {
         { tax: { _id: '19', type: 'VAT', rate: 19 }, amount: 7983 },
       ],
       recurrences: [
-        { type: 'recurring', billing_period: 'monthly', amount_subtotal: 1014, amount_total: 1114, amount_tax: 100 },
-        { type: 'one_time', amount_subtotal: 42017, amount_total: 50000, amount_tax: 7983 },
+        {
+          type: 'recurring',
+          billing_period: 'monthly',
+          amount_subtotal: 1014,
+          amount_total: 1114,
+          unit_amount_gross: 1114,
+          amount_tax: 100,
+        },
+        { type: 'one_time', amount_subtotal: 42017, amount_total: 50000, unit_amount_gross: 50000, amount_tax: 7983 },
       ],
     },
   },
@@ -3703,6 +3814,7 @@ export const priceDetailsForCompositePrice = {
           amount_subtotal: 972,
           amount_total: 1069,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
           pricing_model: 'per_unit',
         },
         {
@@ -3772,6 +3884,7 @@ export const priceDetailsForCompositePrice = {
           amount_subtotal: 42,
           amount_total: 45,
           unit_amount_decimal: '0.45',
+          unit_amount_gross: 45,
           pricing_model: 'per_unit',
         },
         {
@@ -3840,11 +3953,13 @@ export const priceDetailsForCompositePrice = {
           amount_subtotal: 42017,
           amount_total: 50000,
           unit_amount_decimal: '500.00',
+          unit_amount_gross: 50000,
           pricing_model: 'per_unit',
         },
       ],
       amount_subtotal: 43031,
       amount_total: 51114,
+      unit_amount_gross: 51114,
       total_details: {
         amount_tax: 8083,
         breakdown: {
@@ -3859,14 +3974,22 @@ export const priceDetailsForCompositePrice = {
               billing_period: 'monthly',
               amount_subtotal: 1014,
               amount_total: 1114,
+              unit_amount_gross: 1114,
               amount_tax: 100,
             },
-            { type: 'one_time', amount_subtotal: 42017, amount_total: 50000, amount_tax: 7983 },
+            {
+              type: 'one_time',
+              amount_subtotal: 42017,
+              amount_total: 50000,
+              unit_amount_gross: 50000,
+              amount_tax: 7983,
+            },
           ],
         },
       },
     },
   ],
+  unit_amount_gross: 51114,
 };
 
 export const priceDetailsForCompositePriceWithTaxChanges = {
@@ -3880,8 +4003,15 @@ export const priceDetailsForCompositePriceWithTaxChanges = {
         { tax: { _id: '79cac814-18c8-4047-ae45-1d0828598a18', type: 'Custom', rate: 19 }, amount: 3 },
       ],
       recurrences: [
-        { type: 'one_time', amount_subtotal: 10, amount_total: 10, amount_tax: 0 },
-        { type: 'recurring', billing_period: 'monthly', amount_subtotal: 17, amount_total: 20, amount_tax: 3 },
+        { type: 'one_time', amount_subtotal: 10, amount_total: 10, unit_amount_gross: 10, amount_tax: 0 },
+        {
+          type: 'recurring',
+          billing_period: 'monthly',
+          amount_subtotal: 17,
+          amount_total: 20,
+          unit_amount_gross: 20,
+          amount_tax: 3,
+        },
       ],
     },
   },
@@ -3899,6 +4029,7 @@ export const priceDetailsForCompositePriceWithTaxChanges = {
           description: 'one time variable',
           unit_amount: 10,
           unit_amount_decimal: '0.1',
+          unit_amount_gross: 10,
           _price: {
             _id: 'ac541a5a-9a90-4d55-9895-a9fd278203a6',
             unit_amount: 10,
@@ -4053,6 +4184,7 @@ export const priceDetailsForCompositePriceWithTaxChanges = {
           unit_amount_net: 17,
           amount_subtotal: 17,
           amount_total: 20,
+          unit_amount_gross: 20,
           pricing_model: 'per_unit',
         },
       ],
@@ -4154,6 +4286,7 @@ export const priceDetailsForCompositePriceWithTaxChanges = {
       currency: 'EUR',
       amount_subtotal: 27,
       amount_total: 30,
+      unit_amount_gross: 30,
       total_details: {
         amount_tax: 3,
         breakdown: {
@@ -4162,13 +4295,21 @@ export const priceDetailsForCompositePriceWithTaxChanges = {
             { tax: { _id: '79cac814-18c8-4047-ae45-1d0828598a18', type: 'Custom', rate: 19 }, amount: 3 },
           ],
           recurrences: [
-            { type: 'one_time', amount_subtotal: 10, amount_total: 10, amount_tax: 0 },
-            { type: 'recurring', billing_period: 'monthly', amount_subtotal: 17, amount_total: 20, amount_tax: 3 },
+            { type: 'one_time', amount_subtotal: 10, amount_total: 10, unit_amount_gross: 10, amount_tax: 0 },
+            {
+              type: 'recurring',
+              billing_period: 'monthly',
+              amount_subtotal: 17,
+              amount_total: 20,
+              unit_amount_gross: 20,
+              amount_tax: 3,
+            },
           ],
         },
       },
     },
   ],
+  unit_amount_gross: 30,
 };
 
 export const resultsWithCompositePrices = {
@@ -4178,6 +4319,7 @@ export const resultsWithCompositePrices = {
     {
       amount_subtotal: 43031,
       amount_total: 51114,
+      unit_amount_gross: 51114,
       _price: {
         _created_at: '2022-06-15T09:17:08.343Z',
         _id: 'price#4',
@@ -4375,6 +4517,7 @@ export const resultsWithCompositePrices = {
           type: 'recurring',
           unit_amount: 1069,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
           unit_amount_net: 972,
           pricing_model: 'per_unit',
         },
@@ -4445,6 +4588,7 @@ export const resultsWithCompositePrices = {
           unit_amount: 45,
           unit_amount_net: 42,
           unit_amount_decimal: '0.45',
+          unit_amount_gross: 45,
           pricing_model: 'per_unit',
         },
         {
@@ -4513,6 +4657,7 @@ export const resultsWithCompositePrices = {
           unit_amount: 50000,
           unit_amount_net: 42017,
           unit_amount_decimal: '500.00',
+          unit_amount_gross: 50000,
           pricing_model: 'per_unit',
         },
       ],
@@ -4526,6 +4671,7 @@ export const resultsWithCompositePrices = {
               amount_subtotal: 1014,
               amount_tax: 100,
               amount_total: 1114,
+              unit_amount_gross: 1114,
               billing_period: 'monthly',
               type: 'recurring',
             },
@@ -4533,6 +4679,7 @@ export const resultsWithCompositePrices = {
               amount_subtotal: 42017,
               amount_tax: 7983,
               amount_total: 50000,
+              unit_amount_gross: 50000,
               type: 'one_time',
             },
           ],
@@ -4574,10 +4721,11 @@ export const resultsWithCompositePrices = {
           amount_subtotal: 1014,
           amount_tax: 100,
           amount_total: 1114,
+          unit_amount_gross: 1114,
           billing_period: 'monthly',
           type: 'recurring',
         },
-        { amount_subtotal: 42017, amount_tax: 7983, amount_total: 50000, type: 'one_time' },
+        { amount_subtotal: 42017, amount_tax: 7983, amount_total: 50000, unit_amount_gross: 50000, type: 'one_time' },
       ],
       taxes: [
         { amount: 97, tax: { _id: '10', rate: 10, type: 'VAT' } },
@@ -4586,6 +4734,7 @@ export const resultsWithCompositePrices = {
       ],
     },
   },
+  unit_amount_gross: 51114,
 };
 
 export const resultsForSimplePrice = {
@@ -4642,16 +4791,20 @@ export const resultsForSimplePrice = {
       unit_amount: 78946,
       unit_amount_net: 66341,
       unit_amount_decimal: '789.456224456678',
+      unit_amount_gross: 78946,
       pricing_model: 'per_unit',
     },
   ],
   total_details: {
     amount_tax: 12605,
     breakdown: {
-      recurrences: [{ amount_subtotal: 66341, amount_tax: 12605, amount_total: 78946, type: 'one_time' }],
+      recurrences: [
+        { amount_subtotal: 66341, amount_tax: 12605, amount_total: 78946, unit_amount_gross: 78946, type: 'one_time' },
+      ],
       taxes: [{ amount: 12605, tax: { _id: '19', rate: 19, type: 'VAT' } }],
     },
   },
+  unit_amount_gross: 78946,
 };
 
 export const oneItemPerRecurrenceTotals = {
@@ -5031,6 +5184,7 @@ export const resultCompositePriceWithTotalDetails = {
           unit_amount: 1069,
           unit_amount_net: 972,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
         },
         {
           _price: {
@@ -5102,6 +5256,7 @@ export const resultCompositePriceWithTotalDetails = {
           unit_amount: 45,
           unit_amount_net: 42,
           unit_amount_decimal: '0.45',
+          unit_amount_gross: 45,
           pricing_model: 'per_unit',
         },
         {
@@ -5170,6 +5325,7 @@ export const resultCompositePriceWithTotalDetails = {
           unit_amount: 50000,
           unit_amount_net: 42017,
           unit_amount_decimal: '500.00',
+          unit_amount_gross: 50000,
           pricing_model: 'per_unit',
         },
       ],
@@ -5184,10 +5340,17 @@ export const resultCompositePriceWithTotalDetails = {
               amount_subtotal: 2029,
               amount_tax: 199,
               amount_total: 2228,
+              unit_amount_gross: 1114,
               billing_period: 'monthly',
               type: 'recurring',
             },
-            { amount_subtotal: 84034, amount_tax: 15966, amount_total: 100000, type: 'one_time' },
+            {
+              amount_subtotal: 84034,
+              amount_tax: 15966,
+              amount_total: 100000,
+              unit_amount_gross: 50000,
+              type: 'one_time',
+            },
           ],
           taxes: [
             { amount: 194, tax: { _id: '10', rate: 10, type: 'VAT' } },
@@ -5196,14 +5359,22 @@ export const resultCompositePriceWithTotalDetails = {
           ],
         },
       },
+      unit_amount_gross: 51114,
     },
   ],
   total_details: {
     amount_tax: 16166,
     breakdown: {
       recurrences: [
-        { amount_subtotal: 2029, amount_tax: 199, amount_total: 2228, billing_period: 'monthly', type: 'recurring' },
-        { amount_subtotal: 84034, amount_tax: 15966, amount_total: 100000, type: 'one_time' },
+        {
+          amount_subtotal: 2029,
+          amount_tax: 199,
+          amount_total: 2228,
+          unit_amount_gross: 1114,
+          billing_period: 'monthly',
+          type: 'recurring',
+        },
+        { amount_subtotal: 84034, amount_tax: 15966, amount_total: 100000, unit_amount_gross: 50000, type: 'one_time' },
       ],
       taxes: [
         { amount: 194, tax: { _id: '10', rate: 10, type: 'VAT' } },
@@ -5212,4 +5383,5 @@ export const resultCompositePriceWithTotalDetails = {
       ],
     },
   },
+  unit_amount_gross: 51114,
 };

--- a/src/__tests__/fixtures/pricing.results.ts
+++ b/src/__tests__/fixtures/pricing.results.ts
@@ -536,6 +536,7 @@ export const severalItemsPerRecurrenceTotals = {
       description: 'Winter Sale',
       unit_amount: 78946,
       unit_amount_decimal: '789.456224456678',
+      unit_amount_gross: 78946,
       unit_amount_net: 66341,
       amount_subtotal: 331704,
       amount_total: 394728,
@@ -584,6 +585,7 @@ export const severalItemsPerRecurrenceTotals = {
       unit_amount: 3446,
       unit_amount_net: 2895,
       unit_amount_decimal: '34.456224456678',
+      unit_amount_gross: 3446,
       amount_subtotal: 2895,
       amount_total: 3446,
       taxes: [
@@ -664,6 +666,7 @@ export const severalItemsPerRecurrenceTotals = {
       unit_amount: 4546,
       unit_amount_net: 4546,
       unit_amount_decimal: '45.456224456678',
+      unit_amount_gross: 4818,
       amount_subtotal: 13637,
       amount_total: 14455,
       pricing_model: 'per_unit',
@@ -718,6 +721,7 @@ export const severalItemsPerRecurrenceTotals = {
       description: 'Winter Sale',
       unit_amount: 78946,
       unit_amount_decimal: '789.456224456678',
+      unit_amount_gross: 78946,
       unit_amount_net: 66341,
       amount_subtotal: 331704,
       amount_total: 394728,
@@ -782,6 +786,7 @@ export const severalItemsPerRecurrenceTotals = {
       unit_amount: 4546,
       unit_amount_net: 4546,
       unit_amount_decimal: '45.456224456678',
+      unit_amount_gross: 4818,
       amount_subtotal: 13637,
       amount_total: 14455,
       pricing_model: 'per_unit',
@@ -825,12 +830,14 @@ export const severalItemsPerRecurrenceTotals = {
               amount_subtotal: 1014,
               amount_total: 1114,
               amount_tax: 100,
+              unit_amount_gross: 1114,
             },
             {
               type: 'one_time',
               amount_subtotal: 42017,
               amount_total: 50000,
               amount_tax: 7983,
+              unit_amount_gross: 50000,
             },
           ],
         },
@@ -1037,6 +1044,7 @@ export const severalItemsPerRecurrenceTotals = {
           amount_subtotal: 972,
           amount_total: 1069,
           unit_amount_decimal: '10.69',
+          unit_amount_gross: 1069,
           pricing_model: 'per_unit',
         },
         {
@@ -1106,6 +1114,7 @@ export const severalItemsPerRecurrenceTotals = {
           amount_subtotal: 42,
           amount_total: 45,
           unit_amount_decimal: '0.45',
+          unit_amount_gross: 45,
           pricing_model: 'per_unit',
         },
         {
@@ -1172,11 +1181,13 @@ export const severalItemsPerRecurrenceTotals = {
           unit_amount: 50000,
           unit_amount_net: 42017,
           unit_amount_decimal: '500.00',
+          unit_amount_gross: 50000,
           amount_subtotal: 42017,
           amount_total: 50000,
           pricing_model: 'per_unit',
         },
       ],
+      unit_amount_gross: 51114,
     },
   ],
   amount_subtotal: 736609,
@@ -1216,6 +1227,7 @@ export const severalItemsPerRecurrenceTotals = {
           amount_subtotal: 705425,
           amount_total: 839456,
           amount_tax: 134031,
+          unit_amount_gross: 207891,
         },
         {
           type: 'recurring',
@@ -1223,6 +1235,7 @@ export const severalItemsPerRecurrenceTotals = {
           amount_subtotal: 3910,
           amount_total: 4560,
           amount_tax: 650,
+          unit_amount_gross: 4560,
         },
         {
           type: 'recurring',
@@ -1230,10 +1243,12 @@ export const severalItemsPerRecurrenceTotals = {
           amount_subtotal: 27274,
           amount_total: 28910,
           amount_tax: 1636,
+          unit_amount_gross: 9637,
         },
       ],
     },
   },
+  unit_amount_gross: 222088,
 };
 
 export const compositePricesUnitAmountZeroResult = {
@@ -4660,6 +4675,7 @@ export const oneItemPerRecurrenceTotals = {
       ],
       unit_amount: 78946,
       unit_amount_decimal: '789.456224456678',
+      unit_amount_gross: 78946,
       unit_amount_net: 66341,
     },
     {
@@ -4687,6 +4703,7 @@ export const oneItemPerRecurrenceTotals = {
       ],
       unit_amount: 3446,
       unit_amount_decimal: '34.456224456678',
+      unit_amount_gross: 3446,
       unit_amount_net: 2895,
     },
     {
@@ -4714,6 +4731,7 @@ export const oneItemPerRecurrenceTotals = {
       ],
       unit_amount: 4546,
       unit_amount_decimal: '45.456224456678',
+      unit_amount_gross: 4818,
       unit_amount_net: 4546,
     },
     {
@@ -4727,6 +4745,7 @@ export const oneItemPerRecurrenceTotals = {
       taxes: [{ amount: 1364, tax: tax10percent }],
       unit_amount: 4546,
       unit_amount_decimal: '45.456224456678',
+      unit_amount_gross: 5000,
       unit_amount_net: 4546,
     },
   ],
@@ -4765,6 +4784,7 @@ export const oneItemPerRecurrenceTotals = {
           amount_total: 394728,
           amount_tax: 63024,
           type: 'one_time',
+          unit_amount_gross: 78946,
         },
         {
           amount_subtotal: 2895,
@@ -4772,6 +4792,7 @@ export const oneItemPerRecurrenceTotals = {
           billing_period: 'monthly',
           amount_tax: 550,
           type: 'recurring',
+          unit_amount_gross: 3446,
         },
         {
           amount_subtotal: 27274,
@@ -4779,10 +4800,12 @@ export const oneItemPerRecurrenceTotals = {
           amount_tax: 2182,
           billing_period: 'yearly',
           type: 'recurring',
+          unit_amount_gross: 9819,
         },
       ],
     },
   },
+  unit_amount_gross: 92210,
 };
 
 export const resultCompositePriceWithTotalDetails = {

--- a/src/__tests__/fixtures/pricing.results.ts
+++ b/src/__tests__/fixtures/pricing.results.ts
@@ -370,6 +370,7 @@ export const computedCompositePrice: CompositePriceItem & { [key: string]: unkno
 export const resultsWhenPriceIsNontaxable = {
   amount_subtotal: 1000,
   amount_total: 1000,
+  unit_amount_gross: 1000,
   items: [
     {
       _price: {
@@ -404,6 +405,7 @@ export const resultsWhenPriceIsNontaxable = {
       quantity: 1,
       unit_amount: 1000,
       unit_amount_decimal: '10.00',
+      unit_amount_gross: 1000,
       unit_amount_net: 1000,
       taxes: [
         {
@@ -422,6 +424,7 @@ export const resultsWhenPriceIsNontaxable = {
           amount_subtotal: 1000,
           amount_tax: 0,
           amount_total: 1000,
+          unit_amount_gross: 1000,
           billing_period: 'yearly',
           type: 'recurring',
         },
@@ -453,6 +456,7 @@ export const resultsWhenNoPricesProvided = {
       unit_amount: 0,
       unit_amount_net: 0,
       unit_amount_decimal: '0.0',
+      unit_amount_gross: 0,
       _price: {
         pricing_model: 'per_unit',
       },
@@ -474,11 +478,13 @@ export const resultsWhenNoPricesProvided = {
           amount_subtotal: 0,
           amount_tax: 0,
           amount_total: 0,
+          unit_amount_gross: 0,
           type: 'one_time',
         },
       ],
     },
   },
+  unit_amount_gross: 0,
 };
 
 export const severalItemsPerRecurrenceTotals = {
@@ -1543,6 +1549,7 @@ export const compositePricesUnitAmountZeroResult = {
 export const priceWithDisplayOnRequest = {
   amount_subtotal: 0,
   amount_total: 0,
+  unit_amount_gross: 0,
   items: [
     {
       _price: {
@@ -1568,6 +1575,7 @@ export const priceWithDisplayOnRequest = {
       },
       amount_subtotal: 4546,
       amount_total: 5000,
+      unit_amount_gross: 5000,
       currency: 'EUR',
       description: 'Winter Lease',
       price_id: 'price#7',

--- a/src/pricing.test.ts
+++ b/src/pricing.test.ts
@@ -67,7 +67,9 @@ describe('computeAggregatedAndPriceTotals', () => {
 
       const result = computeAggregatedAndPriceTotals(priceItems);
 
-      expect(result).toEqual(expect.objectContaining({ amount_subtotal: 0, amount_total: 0 }));
+      expect(result).toEqual(
+        expect.objectContaining({ amount_subtotal: 0, amount_total: 0, unit_amount_gross: 78946 }),
+      );
     });
 
     it('should return the right result when there is one simple price with display mode "On Request"', () => {
@@ -83,23 +85,27 @@ describe('computeAggregatedAndPriceTotals', () => {
 
       const result = computeAggregatedAndPriceTotals(priceItems);
 
-      expect(result).toEqual(expect.objectContaining({
-        amount_subtotal: 4546, 
-        amount_total: 5000,
-        total_details: expect.objectContaining({
-          breakdown: expect.objectContaining({
-            recurrences: [
-              {
-                amount_subtotal: 4546,
-                amount_tax: 455,
-                amount_total: 5000,
-                type: "recurring",
-                billing_period: "yearly",
-              }
-            ]
-        })
-      })
-      }));
+      expect(result).toEqual(
+        expect.objectContaining({
+          amount_subtotal: 4546,
+          amount_total: 5000,
+          unit_amount_gross: 5000,
+          total_details: expect.objectContaining({
+            breakdown: expect.objectContaining({
+              recurrences: [
+                {
+                  amount_subtotal: 4546,
+                  amount_tax: 455,
+                  amount_total: 5000,
+                  unit_amount_gross: 5000,
+                  type: 'recurring',
+                  billing_period: 'yearly',
+                },
+              ],
+            }),
+          }),
+        }),
+      );
     });
 
     it('should return the right result when there is one simple price with display mode "On Request" and other simple prices', () => {
@@ -132,6 +138,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 0,
             amount_total: 0,
+            unit_amount_gross: 0,
             total_details: expect.objectContaining({
               amount_tax: 0,
             }),
@@ -139,11 +146,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 0,
                 amount_total: 0,
+                unit_amount_gross: 0,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -165,6 +174,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 0,
             amount_total: 0,
+            unit_amount_gross: 0,
             total_details: expect.objectContaining({
               amount_tax: 0,
             }),
@@ -172,11 +182,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 0,
                 amount_total: 0,
+                unit_amount_gross: 0,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -204,6 +216,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 0,
             amount_subtotal: 0,
+            unit_amount_gross: 0,
             total_details: expect.objectContaining({
               amount_tax: 0,
             }),
@@ -211,11 +224,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 0,
                 amount_subtotal: 0,
+                unit_amount_gross: 0,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -242,6 +257,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 1818,
             amount_total: 2000,
+            unit_amount_gross: 1000,
             total_details: expect.objectContaining({
               amount_tax: 182,
             }),
@@ -249,11 +265,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 1818,
                 amount_total: 2000,
+                unit_amount_gross: 1000,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -280,6 +298,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 9091,
             amount_total: 10000,
+            unit_amount_gross: 1000,
             total_details: expect.objectContaining({
               amount_tax: 909,
             }),
@@ -287,11 +306,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 9091,
                 amount_total: 10000,
+                unit_amount_gross: 1000,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -318,6 +339,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 9817,
             amount_total: 10799,
+            unit_amount_gross: 1800,
             total_details: expect.objectContaining({
               amount_tax: 982,
             }),
@@ -325,11 +347,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 9817,
                 amount_total: 10799,
+                unit_amount_gross: 1800,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -356,6 +380,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 12727,
             amount_total: 14000,
+            unit_amount_gross: 1800,
             total_details: expect.objectContaining({
               amount_tax: 1273,
             }),
@@ -363,11 +388,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 12727,
                 amount_total: 14000,
+                unit_amount_gross: 1800,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -394,6 +421,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 66000,
             amount_subtotal: 60000,
+            unit_amount_gross: 2400,
             total_details: expect.objectContaining({
               amount_tax: 6000,
             }),
@@ -401,11 +429,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 66000,
                 amount_subtotal: 60000,
+                unit_amount_gross: 2400,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -429,6 +459,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 0,
             amount_total: 0,
+            unit_amount_gross: 0,
             total_details: expect.objectContaining({
               amount_tax: 0,
             }),
@@ -436,11 +467,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 0,
                 amount_total: 0,
+                unit_amount_gross: 0,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -462,6 +495,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 0,
             amount_total: 0,
+            unit_amount_gross: 0,
             total_details: expect.objectContaining({
               amount_tax: 0,
             }),
@@ -469,11 +503,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 0,
                 amount_total: 0,
+                unit_amount_gross: 0,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -501,6 +537,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 0,
             amount_subtotal: 0,
+            unit_amount_gross: 0,
             total_details: expect.objectContaining({
               amount_tax: 0,
             }),
@@ -508,11 +545,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 0,
                 amount_subtotal: 0,
+                unit_amount_gross: 0,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -528,6 +567,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 1818,
             amount_total: 2000,
+            unit_amount_gross: 1000,
             total_details: expect.objectContaining({
               amount_tax: 182,
             }),
@@ -535,11 +575,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 1818,
                 amount_total: 2000,
+                unit_amount_gross: 1000,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -555,6 +597,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 9091,
             amount_total: 10000,
+            unit_amount_gross: 1000,
             total_details: expect.objectContaining({
               amount_tax: 909,
             }),
@@ -562,11 +605,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 9091,
                 amount_total: 10000,
+                unit_amount_gross: 1000,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -593,6 +638,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 7999,
             amount_total: 8799,
+            unit_amount_gross: 800,
             total_details: expect.objectContaining({
               amount_tax: 800,
             }),
@@ -600,11 +646,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 7999,
                 amount_total: 8799,
+                unit_amount_gross: 800,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -631,6 +679,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 10909,
             amount_total: 12000,
+            unit_amount_gross: 800,
             total_details: expect.objectContaining({
               amount_tax: 1091,
             }),
@@ -638,6 +687,7 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 10909,
                 amount_total: 12000,
+                unit_amount_gross: 800,
               }),
             ]),
           }),
@@ -664,6 +714,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 60000,
             amount_subtotal: 54545,
+            unit_amount_gross: 600,
             total_details: expect.objectContaining({
               amount_tax: 5455,
             }),
@@ -671,6 +722,7 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 60000,
                 amount_subtotal: 54545,
+                unit_amount_gross: 600,
               }),
             ]),
           }),
@@ -694,6 +746,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 0,
             amount_total: 0,
+            unit_amount_gross: 0,
             total_details: expect.objectContaining({
               amount_tax: 0,
             }),
@@ -701,11 +754,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 0,
                 amount_total: 0,
+                unit_amount_gross: 0,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -727,6 +782,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 0,
             amount_total: 0,
+            unit_amount_gross: 0,
             total_details: expect.objectContaining({
               amount_tax: 0,
             }),
@@ -734,11 +790,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 0,
                 amount_total: 0,
+                unit_amount_gross: 0,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -765,6 +823,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 0,
             amount_subtotal: 0,
+            unit_amount_gross: 0,
             total_details: expect.objectContaining({
               amount_tax: 0,
             }),
@@ -772,11 +831,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 0,
                 amount_subtotal: 0,
+                unit_amount_gross: 0,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -799,6 +860,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 10000,
             amount_subtotal: 9091,
+            unit_amount_gross: 10000,
             total_details: expect.objectContaining({
               amount_tax: 909,
             }),
@@ -806,11 +868,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 10000,
                 amount_subtotal: 9091,
+                unit_amount_gross: 10000,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -833,6 +897,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 8000,
             amount_subtotal: 7273,
+            unit_amount_gross: 8000,
             total_details: expect.objectContaining({
               amount_tax: 727,
             }),
@@ -840,11 +905,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 8000,
                 amount_subtotal: 7273,
+                unit_amount_gross: 8000,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -872,6 +939,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 16000,
             amount_subtotal: 14545,
+            unit_amount_gross: 8000,
             total_details: expect.objectContaining({
               amount_tax: 1455,
             }),
@@ -879,11 +947,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 16000,
                 amount_subtotal: 14545,
+                unit_amount_gross: 8000,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -906,6 +976,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 6000,
             amount_subtotal: 5455,
+            unit_amount_gross: 6000,
             total_details: expect.objectContaining({
               amount_tax: 545,
             }),
@@ -913,11 +984,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 6000,
                 amount_subtotal: 5455,
+                unit_amount_gross: 6000,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -940,6 +1013,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 6000,
             amount_subtotal: 5455,
+            unit_amount_gross: 6000,
             total_details: expect.objectContaining({
               amount_tax: 545,
             }),
@@ -947,6 +1021,7 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 6000,
                 amount_subtotal: 5455,
+                unit_amount_gross: 6000,
               }),
             ]),
           }),
@@ -969,6 +1044,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 6000,
             amount_subtotal: 5455,
+            unit_amount_gross: 6000,
             total_details: expect.objectContaining({
               amount_tax: 545,
             }),
@@ -976,6 +1052,7 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 6000,
                 amount_subtotal: 5455,
+                unit_amount_gross: 6000,
               }),
             ]),
           }),
@@ -998,6 +1075,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 6000,
             amount_subtotal: 5455,
+            unit_amount_gross: 6000,
             total_details: expect.objectContaining({
               amount_tax: 545,
             }),
@@ -1005,6 +1083,7 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 6000,
                 amount_subtotal: 5455,
+                unit_amount_gross: 6000,
               }),
             ]),
           }),
@@ -1039,28 +1118,30 @@ describe('computeAggregatedAndPriceTotals', () => {
     });
 
     it('should return the right result when there is one component with display mode "Show as starting price"', () => {
-      const priceItems = [
-        samples.priceComponentDisplayAsStartingPrice,
-      ]
+      const priceItems = [samples.priceComponentDisplayAsStartingPrice];
 
       const result = computeAggregatedAndPriceTotals(priceItems);
 
-      expect(result).toEqual(expect.objectContaining({
-        amount_subtotal: 1800, 
-        amount_total: 1800,
-        total_details: expect.objectContaining({
-          breakdown: expect.objectContaining({
-            recurrences: [
-              {
-                amount_subtotal: 1800,
-                amount_tax: 0,
-                amount_total: 1800,
-                type: "one_time"
-              }
-            ]
-        })
-      })
-      }));
+      expect(result).toEqual(
+        expect.objectContaining({
+          amount_subtotal: 1800,
+          amount_total: 1800,
+          unit_amount_gross: 1800,
+          total_details: expect.objectContaining({
+            breakdown: expect.objectContaining({
+              recurrences: [
+                {
+                  amount_subtotal: 1800,
+                  amount_tax: 0,
+                  amount_total: 1800,
+                  unit_amount_gross: 1800,
+                  type: 'one_time',
+                },
+              ],
+            }),
+          }),
+        }),
+      );
     });
 
     it('should return the right result when there is one composite price with quantity 2', () => {
@@ -1097,6 +1178,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 1000000,
             amount_total: 1190000,
+            unit_amount_gross: 1190,
           }),
         );
       });
@@ -1112,6 +1194,7 @@ describe('computeAggregatedAndPriceTotals', () => {
         expect(result).toEqual({
           amount_subtotal: 53031,
           amount_total: 61114,
+          unit_amount_gross: 52114,
           total_details: expect.anything(),
           items: [
             {
@@ -1126,6 +1209,7 @@ describe('computeAggregatedAndPriceTotals', () => {
                   unit_amount: 1000,
                   unit_amount_currency: 'EUR',
                   unit_amount_decimal: '10.0',
+                  unit_amount_gross: 1000,
                   type: 'one_time',
                   _price: {},
                   _product: {},
@@ -1153,6 +1237,7 @@ describe('computeAggregatedAndPriceTotals', () => {
               currency: 'EUR',
               amount_subtotal: 53031,
               amount_total: 61114,
+              unit_amount_gross: 52114,
               total_details: expect.anything(),
             },
           ],
@@ -1170,6 +1255,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 0,
             amount_total: 0,
+            unit_amount_gross: 1069,
           }),
         );
       });
@@ -1192,6 +1278,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 1818,
             amount_total: 2000,
+            unit_amount_gross: 1000,
             total_details: expect.objectContaining({
               amount_tax: 182,
             }),
@@ -1199,11 +1286,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 1818,
                 amount_total: 2000,
+                unit_amount_gross: 1000,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -1226,6 +1315,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 9091,
             amount_total: 10000,
+            unit_amount_gross: 1000,
             total_details: expect.objectContaining({
               amount_tax: 909,
             }),
@@ -1233,11 +1323,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 9091,
                 amount_total: 10000,
+                unit_amount_gross: 1000,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -1260,6 +1352,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 12727,
             amount_total: 14000,
+            unit_amount_gross: 1800,
             total_details: expect.objectContaining({
               amount_tax: 1273,
             }),
@@ -1267,11 +1360,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 12727,
                 amount_total: 14000,
+                unit_amount_gross: 1800,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -1294,6 +1389,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 66000,
             amount_subtotal: 60000,
+            unit_amount_gross: 2400,
             total_details: expect.objectContaining({
               amount_tax: 6000,
             }),
@@ -1301,11 +1397,13 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 66000,
                 amount_subtotal: 60000,
+                unit_amount_gross: 2400,
               }),
               expect.not.objectContaining({
                 unit_amount: undefined,
                 unit_amount_net: undefined,
                 unit_amount_decimal: undefined,
+                unit_amount_gross: undefined,
               }),
             ]),
           }),
@@ -1330,6 +1428,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 1818,
             amount_total: 2000,
+            unit_amount_gross: 1000,
             total_details: expect.objectContaining({
               amount_tax: 182,
             }),
@@ -1337,6 +1436,7 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 1818,
                 amount_total: 2000,
+                unit_amount_gross: 1000,
               }),
             ]),
           }),
@@ -1359,6 +1459,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 9091,
             amount_total: 10000,
+            unit_amount_gross: 1000,
             total_details: expect.objectContaining({
               amount_tax: 909,
             }),
@@ -1366,6 +1467,7 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 9091,
                 amount_total: 10000,
+                unit_amount_gross: 1000,
               }),
             ]),
           }),
@@ -1388,6 +1490,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_subtotal: 10909,
             amount_total: 12000,
+            unit_amount_gross: 800,
             total_details: expect.objectContaining({
               amount_tax: 1091,
             }),
@@ -1395,6 +1498,7 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_subtotal: 10909,
                 amount_total: 12000,
+                unit_amount_gross: 800,
               }),
             ]),
           }),
@@ -1417,6 +1521,7 @@ describe('computeAggregatedAndPriceTotals', () => {
           expect.objectContaining({
             amount_total: 60000,
             amount_subtotal: 54545,
+            unit_amount_gross: 600,
             total_details: expect.objectContaining({
               amount_tax: 5455,
             }),
@@ -1424,6 +1529,7 @@ describe('computeAggregatedAndPriceTotals', () => {
               expect.objectContaining({
                 amount_total: 60000,
                 amount_subtotal: 54545,
+                unit_amount_gross: 600,
               }),
             ]),
           }),

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -519,8 +519,6 @@ export const computePriceItem: ComputePriceItem = (priceItem, price, applicableT
         )
       : computePriceItemValues(unitAmountDecimal, currency, isTaxInclusive, unitAmountMultiplier, priceTax);
 
-  // console.log({ itemValues });
-
   return {
     ...priceItem,
     currency,

--- a/src/types/pricing-types.d.ts
+++ b/src/types/pricing-types.d.ts
@@ -178,6 +178,10 @@ declare namespace Components {
        */
       readonly unit_amount?: number;
       /**
+       * The unit gross amount value.
+       */
+      readonly unit_amount_gross?: number;
+      /**
        * Total before any (discounts or) taxes are applied.
        */
       readonly amount_subtotal?: number;
@@ -282,6 +286,10 @@ declare namespace Components {
        */
       readonly _product?: {
         [name: string]: any;
+        /**
+         * The description for the product
+         */
+        description?: string;
         /**
          * The product code
          */
@@ -600,6 +608,10 @@ declare namespace Components {
        */
       readonly unit_amount?: number;
       /**
+       * The unit gross amount value.
+       */
+      readonly unit_amount_gross?: number;
+      /**
        * Total before any (discounts or) taxes are applied.
        */
       readonly amount_subtotal?: number;
@@ -709,6 +721,10 @@ declare namespace Components {
        */
       readonly _product?: {
         [name: string]: any;
+        /**
+         * The description for the product
+         */
+        description?: string;
         /**
          * The product code
          */
@@ -1500,6 +1516,10 @@ declare namespace Components {
        */
       readonly unit_amount?: number;
       /**
+       * The unit gross amount value.
+       */
+      readonly unit_amount_gross?: number;
+      /**
        * Total before any (discounts or) taxes are applied.
        */
       readonly amount_subtotal?: number;
@@ -1570,6 +1590,10 @@ declare namespace Components {
        * The unit amount value
        */
       unit_amount?: number;
+      /**
+       * The unit gross amount value.
+       */
+      unit_amount_gross?: number;
       unit_amount_currency?: Currency;
       /**
        * The unit amount in cents to be charged, represented as a decimal string with at most 12 decimal places.
@@ -1771,6 +1795,10 @@ declare namespace Components {
       readonly _product?: {
         [name: string]: any;
         /**
+         * The description for the product
+         */
+        description?: string;
+        /**
          * The product code
          */
         code?: string;
@@ -1879,6 +1907,10 @@ declare namespace Components {
        * Total of all items after (discounts and) taxes are applied.
        */
       amount_total?: number;
+      /**
+       * The unit gross amount value.
+       */
+      unit_amount_gross?: number;
       total_details?: TotalDetails;
     }
     /**
@@ -1890,6 +1922,10 @@ declare namespace Components {
      */
     export interface Product {
       [name: string]: any;
+      /**
+       * The description for the product
+       */
+      description?: string;
       /**
        * The product code
        */
@@ -1989,6 +2025,10 @@ declare namespace Components {
        */
       amount_total: number;
       /**
+       * The unit gross amount value.
+       */
+      unit_amount_gross?: number;
+      /**
        * Total of all items taxes, with same recurrence.
        */
       amount_tax?: number;
@@ -2013,6 +2053,10 @@ declare namespace Components {
        * Total of all items, with same recurrence, after (discounts and) taxes are applied.
        */
       amount_total: number;
+      /**
+       * The unit gross amount value.
+       */
+      unit_amount_gross?: number;
       /**
        * Total of all items taxes, with same recurrence.
        */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@ type GetTaxValue = (tax: Tax) => number;
 type PriceItemsTotals = {
   unitAmount?: number;
   unitAmountNet?: number;
+  unitAmountGross?: number;
   amountSubtotal: number;
   amountTotal: number;
   taxAmount: number;
@@ -89,6 +90,7 @@ export const computePriceItemValues = (
   return {
     unitAmount: unitAmount.getAmount(),
     unitAmountNet: unitAmountNet.getAmount(),
+    unitAmountGross: unitAmountGross.getAmount(),
     amountSubtotal: amountSubtotal.getAmount(),
     amountTotal: amountTotal.getAmount(),
     taxAmount: taxAmount.getAmount(),
@@ -154,6 +156,7 @@ export const computeTieredVolumePriceItemValues = (
     tier?.display_mode === 'on_request' ? 'show_as_on_request' : unchangedPriceDisplayInJourneys;
 
   return {
+    unitAmountGross: d(tierValues.unitAmountGross).getAmount(),
     amountSubtotal: d(tierValues.amountSubtotal).getAmount(),
     amountTotal: d(tierValues.amountTotal).getAmount(),
     taxAmount: d(tierValues.taxAmount).getAmount(),
@@ -191,6 +194,7 @@ export const computeTieredFlatFeePriceItemValues = (
     tier?.display_mode === 'on_request' ? 'show_as_on_request' : unchangedPriceDisplayInJourneys;
 
   return {
+    unitAmountGross: d(tierValues.unitAmountGross).getAmount(),
     amountSubtotal: d(tierValues.amountSubtotal).getAmount(),
     amountTotal: d(tierValues.amountTotal).getAmount(),
     taxAmount: d(tierValues.taxAmount).getAmount(),
@@ -228,13 +232,14 @@ export const computeTieredGraduatedPriceItemValues = (
         tier?.display_mode === 'on_request' ? 'show_as_on_request' : unchangedPriceDisplayInJourneys;
 
       return {
+        unitAmountGross: d(totals.unitAmountGross).add(d(tierValues.unitAmountGross)).getAmount(),
         amountSubtotal: d(totals.amountSubtotal).add(d(tierValues.amountSubtotal)).getAmount(),
         amountTotal: d(totals.amountTotal).add(d(tierValues.amountTotal)).getAmount(),
         taxAmount: d(totals.taxAmount).add(d(tierValues.taxAmount)).getAmount(),
         displayMode,
       };
     },
-    { amountSubtotal: 0, amountTotal: 0, taxAmount: 0 },
+    { unitAmountGross: 0, amountSubtotal: 0, amountTotal: 0, taxAmount: 0 },
   );
 
   /**


### PR DESCRIPTION
Currently the value computed for `unit_amount_gross` is not being returned in `PricingDetails`. This value is useful to display the computation that was performed in other to arrive at the final total result. This PR ensures it is returned, adapts existing tests and fixtures.