### PR TITLE
export Dinero type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/pricing",
-  "version": "4.22.0",
+  "version": "4.22.1",
   "description": "Pricing Library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import DineroConstructor from 'dinero.js'
 
 export { DineroConstructor }
-export type { Currency, Dinero } from 'dinero.js';
 export { DEFAULT_CURRENCY } from './currencies';
 export {
   AmountFormatter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export type { Currency } from 'dinero.js';
+export type { Currency, Dinero } from 'dinero.js';
 export { DEFAULT_CURRENCY } from './currencies';
 export {
   AmountFormatter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import DineroConstructor from 'dinero.js'
+
+export { DineroConstructor }
 export type { Currency, Dinero } from 'dinero.js';
 export { DEFAULT_CURRENCY } from './currencies';
 export {


### PR DESCRIPTION
Export `DineroConstructor` so that we can import in other MFEs that need to handle pricing amount transformations from cents, therefore no need to re-install `dinero.js` again just for that.