### PR TITLE
Feat: Improve function used to normalize numeric values

### DIFF
--- a/src/normalizers/index.test.ts
+++ b/src/normalizers/index.test.ts
@@ -1,6 +1,6 @@
 import { Price } from '../types';
 
-import { normalizePriceMappingInput, normalizeTimeFrequency } from '.';
+import { normalizePriceMappingInput, normalizeValueToFrequencyUnit } from '.';
 
 describe('normalizePriceMappingInput', () => {
   const oneTimePrice = {
@@ -29,48 +29,53 @@ describe('normalizePriceMappingInput', () => {
   );
 });
 
-describe('normalizeTimeFrequency', () => {
+describe('normalizeNumberToFrequency', () => {
   it.each`
-    timeValue   | timeValueFrequency  | targetTimeFrequency | expectedNormalizedValue
-    ${100}      | ${'yearly'}         | ${'weekly'}         | ${1.9231}
-    ${100}      | ${'yearly'}         | ${'monthly'}        | ${8.3333}
-    ${100}      | ${'yearly'}         | ${'every_quarter'}  | ${25}
-    ${100}      | ${'yearly'}         | ${'every_6_months'} | ${50}
-    ${100}      | ${'yearly'}         | ${'yearly'}         | ${100}
-    ${100}      | ${'every_6_months'} | ${'weekly'}         | ${3.8462}
-    ${100}      | ${'every_6_months'} | ${'monthly'}        | ${16.6667}
-    ${100}      | ${'every_6_months'} | ${'every_quarter'}  | ${50}
-    ${100}      | ${'every_6_months'} | ${'every_6_months'} | ${100}
-    ${100}      | ${'every_6_months'} | ${'yearly'}         | ${200}
-    ${100}      | ${'every_quarter'}  | ${'weekly'}         | ${7.6923}
-    ${100}      | ${'every_quarter'}  | ${'monthly'}        | ${33.3333}
-    ${100}      | ${'every_quarter'}  | ${'every_quarter'}  | ${100}
-    ${100}      | ${'every_quarter'}  | ${'every_6_months'} | ${200}
-    ${100}      | ${'every_quarter'}  | ${'yearly'}         | ${400}
-    ${1000}     | ${'monthly'}        | ${'weekly'}         | ${250}
-    ${1000}     | ${'monthly'}        | ${'monthly'}        | ${1000}
-    ${1000}     | ${'monthly'}        | ${'every_quarter'}  | ${3000}
-    ${1000}     | ${'monthly'}        | ${'every_6_months'} | ${6000}
-    ${1000}     | ${'monthly'}        | ${'yearly'}         | ${12000}
-    ${1000}     | ${'weekly'}         | ${'weekly'}         | ${1000}
-    ${1000}     | ${'weekly'}         | ${'monthly'}        | ${4000}
-    ${1000}     | ${'weekly'}         | ${'every_quarter'}  | ${13000}
-    ${1000}     | ${'weekly'}         | ${'every_6_months'} | ${26000}
-    ${1000}     | ${'weekly'}         | ${'yearly'}         | ${52000}
-    ${0.387676} | ${'weekly'}         | ${'monthly'}        | ${1.5507}
-    ${36.32422} | ${'yearly'}         | ${'monthly'}        | ${3.027}
-    ${24000}    | ${'yearly'}         | ${'Monthly'}        | ${2000}
-    ${24000}    | ${'yearly'}         | ${undefined}        | ${24000}
-    ${24000}    | ${undefined}        | ${'monthly'}        | ${24000}
-    ${'2400.5'} | ${'monthly'}        | ${'weekly'}         | ${600.125}
-    ${'1000'}   | ${'monthly'}        | ${'yearly'}         | ${12000}
-    ${'1000.50'}| ${'monthly'}        | ${'yearly'}         | ${12006}
-    ${'12006'}  | ${'yearly'}        | ${'monthly'}         | ${1000.50}
-    ${'159.345'}| ${'yearly'}        | ${'monthly'}         | ${13.2788}
+    timeValue    | timeValueFrequency  | targetTimeFrequency | precision    | expectedNormalizedValue
+    ${100}       | ${'yearly'}         | ${'weekly'}         | ${4}         | ${1.9231}
+    ${100}       | ${'yearly'}         | ${'monthly'}        | ${4}         | ${8.3333}
+    ${100}       | ${'yearly'}         | ${'monthly'}        | ${6}         | ${8.333333}
+    ${100}       | ${'yearly'}         | ${'every_quarter'}  | ${4}         | ${25}
+    ${100}       | ${'yearly'}         | ${'every_6_months'} | ${4}         | ${50}
+    ${100}       | ${'yearly'}         | ${'yearly'}         | ${4}         | ${100}
+    ${100}       | ${'every_6_months'} | ${'weekly'}         | ${4}         | ${3.8462}
+    ${100}       | ${'every_6_months'} | ${'monthly'}        | ${4}         | ${16.6667}
+    ${100}       | ${'every_6_months'} | ${'every_quarter'}  | ${4}         | ${50}
+    ${100}       | ${'every_6_months'} | ${'every_6_months'} | ${4}         | ${100}
+    ${100}       | ${'every_6_months'} | ${'yearly'}         | ${4}         | ${200}
+    ${100}       | ${'every_quarter'}  | ${'weekly'}         | ${4}         | ${7.6923}
+    ${100}       | ${'every_quarter'}  | ${'monthly'}        | ${4}         | ${33.3333}
+    ${100}       | ${'every_quarter'}  | ${'every_quarter'}  | ${4}         | ${100}
+    ${100}       | ${'every_quarter'}  | ${'every_6_months'} | ${4}         | ${200}
+    ${100}       | ${'every_quarter'}  | ${'yearly'}         | ${4}         | ${400}
+    ${1000}      | ${'monthly'}        | ${'weekly'}         | ${4}         | ${250}
+    ${1000}      | ${'monthly'}        | ${'monthly'}        | ${4}         | ${1000}
+    ${1000}      | ${'monthly'}        | ${'every_quarter'}  | ${4}         | ${3000}
+    ${1000}      | ${'monthly'}        | ${'every_6_months'} | ${4}         | ${6000}
+    ${1000}      | ${'monthly'}        | ${'yearly'}         | ${4}         | ${12000}
+    ${1000}      | ${'weekly'}         | ${'weekly'}         | ${4}         | ${1000}
+    ${1000}      | ${'weekly'}         | ${'monthly'}        | ${4}         | ${4000}
+    ${1000}      | ${'weekly'}         | ${'every_quarter'}  | ${4}         | ${13000}
+    ${1000}      | ${'weekly'}         | ${'every_6_months'} | ${4}         | ${26000}
+    ${1000}      | ${'weekly'}         | ${'yearly'}         | ${4}         | ${52000}
+    ${0.387676}  | ${'weekly'}         | ${'monthly'}        | ${4}         | ${1.5507}
+    ${36.32422}  | ${'yearly'}         | ${'monthly'}        | ${4}         | ${3.027}
+    ${24000}     | ${'yearly'}         | ${'Monthly'}        | ${4}         | ${2000}
+    ${24000}     | ${'yearly'}         | ${undefined}        | ${4}         | ${24000}
+    ${24000}     | ${undefined}        | ${'monthly'}        | ${4}         | ${24000}
+    ${'2400.5'}  | ${'monthly'}        | ${'weekly'}         | ${4}         | ${'600.125'}
+    ${'1000'}    | ${'monthly'}        | ${'yearly'}         | ${4}         | ${'12000'}
+    ${'1000.50'} | ${'monthly'}        | ${'yearly'}         | ${4}         | ${'12006'}
+    ${'12006'}   | ${'yearly'}         | ${'monthly'}        | ${4}         | ${'1000.5'}
+    ${'159.345'} | ${'yearly'}         | ${'monthly'}        | ${4}         | ${'13.2788'}
+    ${'159.345'} | ${'yearly'}         | ${'monthly'}        | ${undefined} | ${'13.27875'}
+    ${'159.345'} | ${'yearly'}         | ${'monthly'}        | ${12}        | ${'13.27875'}
+    ${'10000'}   | ${'yearly'}         | ${'monthly'}        | ${12}        | ${'833.333333333333'}
+    ${'10000'}   | ${'yearly'}         | ${'monthly'}        | ${2}         | ${'833.33'}
   `(
     `should normalize $timeValue/$timeValueFrequency properly to time frequency $targetTimeFrequency`,
-    ({ timeValue, timeValueFrequency, targetTimeFrequency, expectedNormalizedValue }) => {
-      expect(normalizeTimeFrequency(timeValue, timeValueFrequency, targetTimeFrequency)).toStrictEqual(
+    ({ timeValue, timeValueFrequency, targetTimeFrequency, precision, expectedNormalizedValue }) => {
+      expect(normalizeValueToFrequencyUnit(timeValue, timeValueFrequency, targetTimeFrequency, precision)).toStrictEqual(
         expectedNormalizedValue,
       );
     },

--- a/src/normalizers/index.ts
+++ b/src/normalizers/index.ts
@@ -4,6 +4,7 @@ import { toDinero } from '../formatters';
 import {
   NormalizeTimeFrequency,
   NormalizeTimeFrequencyToDinero,
+  NormalizeValueToFrequencyUnit,
   Price,
   PriceInputMapping,
   TimeFrequency,
@@ -99,6 +100,7 @@ export const normalizeTimeFrequencyToDinero: NormalizeTimeFrequencyToDinero = (
  *
  * @returns {number} normalizedFrequencyInput
  *
+ * @deprecated The method will be removed in the next major version. Use normalizeValueToFrequencyUnit instead.
  * See also {@link TimeFrequency}
  */
 export const normalizeTimeFrequency: NormalizeTimeFrequency = (
@@ -118,4 +120,38 @@ export const normalizeTimeFrequency: NormalizeTimeFrequency = (
       .convertPrecision(targetPrecision)
       .toFormat('0.0000'),
   );
+};
+
+/**
+ * This function will normalize an inputted value of a specific time frequency to the
+ * desired time frequency based on constant values defined here {@link timeFrequencyNormalizerMatrix}.
+ *
+ * The default precision is set to 4 decimal places.
+ *
+ * @param {number} value the value that will be normalized
+ * @param {TimeFrequency} timeValueFrequency the current time frequency of the value
+ * @param {TimeFrequency} targetTimeFrequency the time frequency the value will be normalized to
+ * @param {number} precision the precision of the normalized value
+ *
+ * @returns {number | string} normalized value
+ * See also {@link TimeFrequency}
+ */
+export const normalizeValueToFrequencyUnit: NormalizeValueToFrequencyUnit = (
+  value,
+  timeValueFrequency,
+  targetTimeFrequency,
+  precision,
+) => {
+  const safePrecision = precision ? precision : typeof value === 'number' ? 4 : 12;
+
+  const normalizedValue = normalizeTimeFrequencyToDinero(
+    value,
+    timeValueFrequency?.toLowerCase() as TimeFrequency,
+    targetTimeFrequency?.toLocaleLowerCase() as TimeFrequency,
+  )
+    .convertPrecision(safePrecision)
+    .toUnit()
+    .toString();
+
+  return typeof value === 'string' ? normalizedValue : Number(normalizedValue);
 };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -32,6 +32,13 @@ export type NormalizeTimeFrequency = (
   targetTimeFrequency: TimeFrequency,
   precision?: number,
 ) => number;
+export type NormalizeValueToFrequencyUnit = (
+  timeValue: number | string,
+  timeValueFrequency: TimeFrequency,
+  targetTimeFrequency: TimeFrequency,
+  precision?: number,
+) => number | string;
+
 export type NormalizeTimeFrequencyToDinero = (
   timeValue: number | string,
   timeValueFrequency: TimeFrequency,


### PR DESCRIPTION
The function being deprecated was dealing only with values from the type `number`. Now we need to deal with decimal values, the ones comming from getAG, that's why I'm extending the function to handle strings and return strings too.