### PR TITLE
chore: add additional price item getag data

### DIFF
--- a/src/__tests__/fixtures/price-getag.samples.ts
+++ b/src/__tests__/fixtures/price-getag.samples.ts
@@ -155,60 +155,12 @@ export const compositePriceGetAG: PriceItemDto = {
       is_composite_price: true,
       _schema: "price",
       _id: "price#1",
-      getag_price: {
-        amount_total: 3126,
-        amount_total_decimal: "31.26",
-        amount_static: 3126,
-        amount_static_decimal: "31.26",
-        amount_variable: 0,
-        amount_variable_decimal: "0.000000000000",
-        currency: "EUR",
-        billing_period: "yearly",
-        breakdown: {
-          static: {
-            basic_fee: {
-              amount: 1921,
-              amount_decimal: "19.21"
-            },
-            maintenance_fee: {
-              amount: 1205,
-              amount_decimal: "12.05"
-            }
-          },
-          variable: {
-            offshore_liability_fee: {
-              amount: 0,
-              amount_decimal: "0"
-            },
-            interruptible_load: {
-              amount: 0,
-              amount_decimal: "0"
-            },
-            extra_charge: {
-              amount: 0,
-              amount_decimal: "0"
-            },
-            chp: {
-              amount: 0,
-              amount_decimal: "0"
-            },
-            power_kwh: {
-              amount: 0,
-              amount_decimal: "0"
-            },
-            concession: {
-              amount: 0,
-              amount_decimal: "0"
-            }
-          }
-        }
-      }
     },
     price_mappings: [
       { price_id: 'comp#2', value: 12000, frequency_unit: 'yearly' }
     ],
     external_fees_mappings: [
-      { price_id: 'comp#1', amount_total: 3126, amount_total_decimal: '54.26' ,frequency_unit: 'yearly' },
+      { price_id: 'comp#1', amount_total: 5426, amount_total_decimal: '54.26' ,frequency_unit: 'yearly' },
       { price_id: 'comp#2', amount_total: 142632, amount_total_decimal: '1426.32' ,frequency_unit: 'yearly' }
     ]
   } as any

--- a/src/pricing-getag.test.ts
+++ b/src/pricing-getag.test.ts
@@ -1,24 +1,34 @@
-import { compositePriceGetAG, priceGetAG } from './__tests__/fixtures/price-getag.samples'
+import { compositePriceGetAG, priceGetAG } from './__tests__/fixtures/price-getag.samples';
 import { computeAggregatedAndPriceTotals } from './pricing';
 import { PriceItemDto } from './types';
 
 describe('GetAG - computeAggregatedAndPriceTotals', () => {
-
   describe('when is_composite_price = false', () => {
     it('returns the correct amount_total', () => {
-      const priceItems: PriceItemDto[] = [
-        priceGetAG
-      ];
-  
+      const priceItems: PriceItemDto[] = [priceGetAG];
+
       const result = computeAggregatedAndPriceTotals(priceItems);
 
-      expect(result).toStrictEqual(expect.objectContaining({
-        amount_total: 24144,
-        amount_subtotal: 20289,
-        amount_tax: 3855,
-        total_details: expect.objectContaining({
-          breakdown: 
+      expect(result).toStrictEqual(
+        expect.objectContaining({
+          amount_total: 24144,
+          amount_subtotal: 20289,
+          amount_tax: 3855,
+          items: expect.arrayContaining([
             expect.objectContaining({
+              get_ag: expect.objectContaining({
+                category: 'power',
+                markup_amount: 10,
+                markup_amount_decimal: '0.10',
+                unit_amount_gross: 14,
+                unit_amount_gross_decimal: '0.1414434',
+                unit_amount_net: 12,
+                unit_amount_net_decimal: '0.11886',
+              }),
+            }),
+          ]),
+          total_details: expect.objectContaining({
+            breakdown: expect.objectContaining({
               recurrences: expect.arrayContaining([
                 expect.objectContaining({
                   amount_total: 24144,
@@ -27,26 +37,53 @@ describe('GetAG - computeAggregatedAndPriceTotals', () => {
                 }),
               ]),
             }),
+          }),
         }),
-      }));
-    })
-  })
+      );
+    });
+  });
 
   describe('when is_composite_price = true', () => {
     it('returns the correct amount_total', () => {
-      const priceItems: PriceItemDto[] = [
-        compositePriceGetAG
-      ];
-  
+      const priceItems: PriceItemDto[] = [compositePriceGetAG];
+
       const result = computeAggregatedAndPriceTotals(priceItems);
 
-      expect(result).toStrictEqual(expect.objectContaining({
-        amount_total: 25682,
-        amount_subtotal: 21582,
-        amount_tax: 4101,
-        total_details: expect.objectContaining({
-          breakdown: 
+      expect(result).toStrictEqual(
+        expect.objectContaining({
+          amount_total: 25682,
+          amount_subtotal: 21582,
+          amount_tax: 4101,
+          items: expect.arrayContaining([
             expect.objectContaining({
+              item_components: expect.arrayContaining([
+                expect.objectContaining({
+                  get_ag: expect.objectContaining({
+                    category: 'power',
+                    markup_amount: 1000,
+                    markup_amount_decimal: '10.00',
+                    unit_amount_gross: 538,
+                    unit_amount_gross_decimal: '5.380783333334',
+                    unit_amount_net: 452,
+                    unit_amount_net_decimal: '4.521666666667',
+                  }),
+                }),
+                expect.objectContaining({
+                  get_ag: expect.objectContaining({
+                    category: 'power',
+                    markup_amount: 10,
+                    markup_amount_decimal: '0.10',
+                    unit_amount_gross: 14,
+                    unit_amount_gross_decimal: '0.1414434',
+                    unit_amount_net: 12,
+                    unit_amount_net_decimal: '0.11886',
+                  }),
+                }),
+              ]),
+            }),
+          ]),
+          total_details: expect.objectContaining({
+            breakdown: expect.objectContaining({
               recurrences: expect.arrayContaining([
                 expect.objectContaining({
                   amount_total: 25682,
@@ -55,8 +92,9 @@ describe('GetAG - computeAggregatedAndPriceTotals', () => {
                 }),
               ]),
             }),
+          }),
         }),
-      }));
-    })
+      );
+    });
   });
 });

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -267,7 +267,6 @@ export const computeCompositePrice = (
  */
 
 export const computeAggregatedAndPriceTotals = (priceItems: PriceItemsDto): PricingDetails => {
-  // console.log('computeAggregatedAndPriceTotals ~ locally');
   const initialPricingDetails: PricingDetails = {
     items: [],
     amount_subtotal: 0,
@@ -348,8 +347,6 @@ export const computeAggregatedAndPriceTotals = (priceItems: PriceItemsDto): Pric
   }, initialPricingDetails);
 
   priceDetails.currency = (priceDetails?.items?.[0]?.currency as Currency) || DEFAULT_CURRENCY;
-
-  // console.log('result', convertPricingPrecision(priceDetails, 2));
 
   return convertPricingPrecision(priceDetails, 2);
 };
@@ -697,6 +694,7 @@ export const computePriceItem = (
     amount_subtotal: itemValues.amountSubtotal,
     amount_total: itemValues.amountTotal,
     amount_tax: itemValues.taxAmount,
+    ...(itemValues.getAg && { get_ag: itemValues.getAg }),
     taxes: [
       {
         ...(priceTax ? { tax: priceTax } : { rate: 'nontaxable', rateValue: 0 }),
@@ -741,6 +739,15 @@ const convertPriceItemPrecision = (priceItem: PriceItem, precision = 2): PriceIt
     ...tax,
     amount: d(tax.amount!).convertPrecision(precision).getAmount(),
   })),
+  ...(priceItem.get_ag && {
+    get_ag: {
+      ...priceItem.get_ag,
+      unit_amount_net: d(priceItem.get_ag.unit_amount_net).convertPrecision(precision).getAmount(),
+      unit_amount_gross: d(priceItem.get_ag.unit_amount_gross).convertPrecision(precision).getAmount(),
+      unit_amount_net_decimal: d(priceItem.get_ag.unit_amount_net).toUnit().toString(),
+      unit_amount_gross_decimal: d(priceItem.get_ag.unit_amount_gross).toUnit().toString(),
+    },
+  }),
 });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2,7 +2,9 @@ import { Components } from '@epilot/pricing-client';
 import type { Dinero } from 'dinero.js';
 
 export type Price = Components.Schemas.Price;
-export type PriceItem = Components.Schemas.PriceItem;
+export type PriceItem = Components.Schemas.PriceItem & {
+  get_ag?: PriceItemGetAgConfig;
+};
 export type PriceItemDto = Components.Schemas.PriceItemDto;
 export type Product = Components.Schemas.Product;
 export type PricingDetails = Components.Schemas.PricingDetails;
@@ -47,3 +49,16 @@ export type NormalizeTimeFrequencyToDinero = (
   targetTimeFrequency: TimeFrequency,
   precision?: number,
 ) => Dinero;
+
+export type PriceGetAgConfig = {
+  category: string;
+  markup_amount: number;
+  markup_amount_decimal: string;
+};
+
+export type PriceItemGetAgConfig = PriceGetAgConfig & {
+  unit_amount_gross: number;
+  unit_amount_gross_decimal?: string;
+  unit_amount_net: number;
+  unit_amount_net_decimal?: string;
+};


### PR DESCRIPTION
Adds getag additional data containing info like the unit amounts of this external component. Types will be properly updated next, when confirmed this is enough.