### PR TITLE
chore: fix edge case making sure correct default amounts are returned…

### DIFF
--- a/src/pricing-getag.test.ts
+++ b/src/pricing-getag.test.ts
@@ -84,6 +84,18 @@ describe('GetAG - computeAggregatedAndPriceTotals', () => {
         }),
       );
     });
+    
+    it('returns the default amount_total if no external fees mappings are passed', () => {
+      const priceItems: PriceItemDto[] = [{
+        ...priceGetAG,
+        external_fees_mappings: undefined
+      }];
+
+      const result = computeAggregatedAndPriceTotals(priceItems);
+
+      expect(result).toBeDefined();
+      expect(result.amount_total).toBe(0);
+    });
   });
 
   describe('when is_composite_price = true', () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -336,6 +336,11 @@ export const computeExternalGetAGPriceItemValues = (
       taxAmount: 0,
       amountSubtotal: 0,
       amountTotal: 0,
+      getAg: {
+        ...getAg,
+        unit_amount_net: 0,
+        unit_amount_gross: 0,
+      },
     };
   }
 


### PR DESCRIPTION
When we use GetAG products in preview in the journey builder configurator, we do not have external fees mappings. By default, the code should not break, default zero amounts need to be returned. We were doing already this but we forgot to do it for a new prop recently introduced.