### PR TITLE
chore: fix amount taxes for immutable external data price items

### DIFF
--- a/src/__tests__/fixtures/price-external-data.samples.ts
+++ b/src/__tests__/fixtures/price-external-data.samples.ts
@@ -260,6 +260,7 @@ export const externalCompositePrice: PriceItemDto = {
                           "amount_subtotal_decimal": "50",
                           "amount_subtotal": 5000,
                           "unit_amount": 5000,
+                          "amount_tax": 1000,
                           "unit_amount_gross": 6000,
                           "unit_amount_gross_decimal": "60",
                           "unit_amount_net": 5000,
@@ -314,6 +315,7 @@ export const externalCompositePrice: PriceItemDto = {
                           "amount_subtotal_decimal": "8.4",
                           "amount_subtotal": 840,
                           "unit_amount": 840,
+                          "amount_tax": 160,
                           "unit_amount_gross": 1000,
                           "unit_amount_gross_decimal": "10",
                           "unit_amount_net": 840,
@@ -365,14 +367,16 @@ export const externalCompositePrice: PriceItemDto = {
                                   "amount_subtotal_decimal": "150",
                                   "amount_total_decimal": "160",
                                   "amount_subtotal": 15000,
-                                  "amount_total": 16000
+                                  "amount_total": 16000,
+                                  "amount_tax": 1000
                               },
                               {
                                   "type": "one_time",
                                   "amount_subtotal_decimal": "8.4",
                                   "amount_total_decimal": "10",
                                   "amount_subtotal": 840,
-                                  "amount_total": 1000
+                                  "amount_total": 1000,
+                                  "amount_tax": 160
                               }
                           ]
                       }
@@ -510,14 +514,16 @@ export const externalCompositePrice: PriceItemDto = {
                           "amount_subtotal_decimal": "150",
                           "amount_total_decimal": "160",
                           "amount_subtotal": 15000,
-                          "amount_total": 16000
+                          "amount_total": 16000,
+                          "amount_tax": 1000
                       },
                       {
                           "type": "one_time",
                           "amount_subtotal_decimal": "8.4",
                           "amount_total_decimal": "10",
                           "amount_subtotal": 840,
-                          "amount_total": 1000
+                          "amount_total": 1000,
+                          "amount_tax": 160
                       }
                   ]
               }

--- a/src/pricing-immutable-data.test.ts
+++ b/src/pricing-immutable-data.test.ts
@@ -44,24 +44,29 @@ describe('Immutable data - computeAggregatedAndPriceTotals', () => {
       const simpleExternalOneTimePriceItem = computedItems?.find((item) => item._price?._id === 'price-73f857a4-0fbc-4aa6-983f-87c0d6d410a6') as PriceItem
       const totalDetailsBreakdown = result.total_details?.breakdown;
       const externalCompositePriceTotalDetailsBreakdown = externalCompositePriceItem?.total_details?.breakdown
-  
       const oneTimeTotalRecurrence = totalDetailsBreakdown?.recurrences?.find((recurrence) => recurrence.type === 'one_time');
       const monthlyTotalRecurrence = totalDetailsBreakdown?.recurrences?.find((recurrence) => recurrence.type === 'recurring' && recurrence.billing_period === 'monthly');
       const oneTimeExternalCompositePriceRecurrence = externalCompositePriceTotalDetailsBreakdown?.recurrences?.find((recurrence) => recurrence.type === 'one_time');
       const monthlyExternalCompositePriceRecurrence = externalCompositePriceTotalDetailsBreakdown?.recurrences?.find((recurrence) => recurrence.type === 'recurring' && recurrence.billing_period === 'monthly');
-
+      
       expect(oneTimeTotalRecurrence?.amount_total).toBe(51590);
       expect(oneTimeTotalRecurrence?.amount_total_decimal).toBe("515.9048");
+      expect(oneTimeTotalRecurrence?.amount_tax).toBe(3400);
       expect(monthlyTotalRecurrence?.amount_total).toBe(32000);
       expect(monthlyTotalRecurrence?.amount_total_decimal).toBe("320");
+      expect(monthlyTotalRecurrence?.amount_tax).toBe(2000);
       expect(oneTimeExternalCompositePriceRecurrence?.amount_total).toBe(1000);
       expect(oneTimeExternalCompositePriceRecurrence?.amount_subtotal).toBe(840);
+      expect(oneTimeExternalCompositePriceRecurrence?.amount_tax).toBe(160);
       expect(monthlyExternalCompositePriceRecurrence?.amount_total).toBe(16000);
       expect(monthlyExternalCompositePriceRecurrence?.amount_subtotal).toBe(15000);
+      expect(monthlyExternalCompositePriceRecurrence?.amount_tax).toBe(1000);
       expect(simpleInternalOneTimePriceItem?.amount_total).toBe(23045);
       expect(simpleInternalOneTimePriceItem?.amount_total_decimal).toBe("230.4524");
+      expect(simpleInternalOneTimePriceItem?.amount_tax).toBe(1508);
       expect(simpleExternalOneTimePriceItem?.amount_total).toBe(2500);
       expect(simpleExternalOneTimePriceItem?.amount_total_decimal).toBe("25");
+      expect(simpleExternalOneTimePriceItem?.amount_tax).toBe(0);
     });
   });
 });

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -257,12 +257,17 @@ export const computeCompositePrice = (
 };
 
 const convertAmountsToDinero = <Item extends PriceItem | CompositePriceItem>(item: Item): Item => {
+  const dineroTotal = toDinero(item.amount_total_decimal || '0');
+  const dineroSubtotal = toDinero(item.amount_subtotal_decimal || '0');
+
   return {
     ...item,
-    amount_total: toDinero(item.amount_total_decimal || '0').getAmount(),
-    amount_subtotal: toDinero(item.amount_subtotal_decimal || '0').getAmount(),
+    amount_total: dineroTotal.getAmount(),
+    amount_subtotal: dineroSubtotal.getAmount(),
     unit_amount_gross: toDinero(item.unit_amount_gross_decimal || '0').getAmount(),
     unit_amount_net: toDinero(item.unit_amount_net_decimal || '0').getAmount(),
+    unit_amount: toDinero(item.unit_amount_decimal || '0').getAmount(),
+    amount_tax: dineroTotal.subtract(dineroSubtotal).getAmount(),
   };
 };
 
@@ -460,7 +465,7 @@ const recomputeDetailTotals = (
     typeof priceItemToAppend.before_discount_amount_total !== 'undefined'
       ? toDineroFromInteger(priceItemToAppend.before_discount_amount_total!)
       : undefined;
-  const priceTax = toDineroFromInteger(priceItemToAppend.taxes?.[0]?.amount || 0);
+  const priceTax = toDineroFromInteger(priceItemToAppend.taxes?.[0]?.amount || priceItemToAppend.amount_tax || 0);
 
   if (tax) {
     tax.amount = toDineroFromInteger(tax.amount!).add(priceTax).getAmount();


### PR DESCRIPTION
Context: 
- Currently we always recalculate the tax(es) in the lib to take advantage of full precision (dinero 12 decimal places) and some advanced tax configs for total details computation (btw, that's why we dont have for example an amount_tax_decimal property in our schemas). For external price items we need to have a similar approach and make sure we have the tax amount also with full precision, this PR includes quick solution for that.