### PR TITLE
chore: fix check against getag pricing model for price item precision…

### DIFF
--- a/src/__tests__/fixtures/price-getag.samples.ts
+++ b/src/__tests__/fixtures/price-getag.samples.ts
@@ -22,7 +22,6 @@ export const priceGetAG: PriceItemDto = {
     _tags: [],
   },
   type: 'recurring',
-  pricing_model: 'external_getag',
   get_ag: {
     category: 'power',
     markup_amount: 10,

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -977,7 +977,8 @@ const convertPriceItemPrecision = (priceItem: PriceItem, precision = 2): PriceIt
     }),
   }),
   ...(priceItem.get_ag &&
-    priceItem.pricing_model === PricingModel.externalGetAG && {
+    (priceItem.pricing_model === PricingModel.externalGetAG ||
+      priceItem._price?.pricing_model === PricingModel.externalGetAG) && {
       get_ag: {
         ...priceItem.get_ag,
         unit_amount_net: toDineroFromInteger(priceItem.get_ag.unit_amount_net).convertPrecision(precision).getAmount(),


### PR DESCRIPTION
Fallback to _price when checking against getag pricing model