### PR TITLE
WIP: feat: support cashbacks computation for composite prices

### DIFF
--- a/src/__tests__/fixtures/coupon.samples.ts
+++ b/src/__tests__/fixtures/coupon.samples.ts
@@ -66,7 +66,7 @@ export const fixedCashbackCoupon: Coupon = {
   fixed_value: 1000,
   fixed_value_decimal: '10.00',
   fixed_value_currency: 'EUR',
-  cashback_period: '12',
+  cashback_period: '0',
 };
 
 export const lowFixedCashbackCoupon: Coupon = {

--- a/src/__tests__/fixtures/coupon.samples.ts
+++ b/src/__tests__/fixtures/coupon.samples.ts
@@ -66,7 +66,7 @@ export const fixedCashbackCoupon: Coupon = {
   fixed_value: 1000,
   fixed_value_decimal: '10.00',
   fixed_value_currency: 'EUR',
-  cashback_period: '0',
+  cashback_period: '12',
 };
 
 export const lowFixedCashbackCoupon: Coupon = {
@@ -82,7 +82,7 @@ export const lowFixedCashbackCoupon: Coupon = {
   fixed_value: 500,
   fixed_value_decimal: '5.00',
   fixed_value_currency: 'EUR',
-  cashback_period: '12',
+  cashback_period: '0',
 };
 
 export const percentageCashbackCoupon: Coupon = {

--- a/src/__tests__/fixtures/coupon.samples.ts
+++ b/src/__tests__/fixtures/coupon.samples.ts
@@ -69,6 +69,22 @@ export const fixedCashbackCoupon: Coupon = {
   cashback_period: '12',
 };
 
+export const lowFixedCashbackCoupon: Coupon = {
+  _id: 'coupon#4',
+  _schema: 'coupon',
+  _org: 'org#1',
+  _created_at: '2022-06-15T09:17:06.510Z',
+  _updated_at: '2022-06-17T11:48:20.104Z',
+  _title: 'VIP Cashback',
+  name: 'VIP Cashback',
+  type: 'fixed',
+  category: 'cashback',
+  fixed_value: 500,
+  fixed_value_decimal: '5.00',
+  fixed_value_currency: 'EUR',
+  cashback_period: '12',
+};
+
 export const percentageCashbackCoupon: Coupon = {
   _id: 'coupon#3',
   _schema: 'coupon',

--- a/src/__tests__/fixtures/price.samples.ts
+++ b/src/__tests__/fixtures/price.samples.ts
@@ -11,6 +11,7 @@ import {
 import {
   fixedCashbackCoupon,
   fixedDiscountCoupon,
+  lowFixedCashbackCoupon,
   highFixedDiscountCoupon,
   highPercentageDiscountCoupon,
   percentage10DiscountCoupon,
@@ -3345,3 +3346,57 @@ export const compositePriceWithComponentsWithPromoCodeRequiredCoupon: CompositeP
     ],
   },
 };
+
+export const compositePriceWithFixedCashbackCoupon: CompositePriceItemDto = {
+  ...compositePriceWithComponentsWithCoupons,
+  _coupons: [fixedCashbackCoupon],
+  _price: {
+    ...compositePriceWithComponentsWithCoupons._price,
+    price_components: [
+      {
+        ...(compositePriceWithComponentsWithCoupons._price!.price_components as Price)[0]!,
+        _coupons: [],
+      },
+      {
+        ...(compositePriceWithComponentsWithCoupons._price!.price_components as Price)[1]!,
+        _coupons: [],
+      },
+    ],
+  },
+}
+
+export const compositePriceWithPercentageCashbackCoupon: CompositePriceItemDto = {
+  ...compositePriceWithComponentsWithCoupons,
+  _coupons: [percentageCashbackCoupon],
+  _price: {
+    ...compositePriceWithComponentsWithCoupons._price,
+    price_components: [
+      {
+        ...(compositePriceWithComponentsWithCoupons._price!.price_components as Price)[0]!,
+        _coupons: [],
+      },
+      {
+        ...(compositePriceWithComponentsWithCoupons._price!.price_components as Price)[1]!,
+        _coupons: [],
+      },
+    ],
+  },
+}
+
+export const compositePriceCashbackCombinedWithComponentCashbacks: CompositePriceItemDto = {
+  ...compositePriceWithComponentsWithCoupons,
+  _coupons: [fixedCashbackCoupon],
+  _price: {
+    ...compositePriceWithComponentsWithCoupons._price,
+    price_components: [
+      {
+        ...(compositePriceWithComponentsWithCoupons._price!.price_components as Price)[0]!,
+        _coupons: [],
+      },
+      {
+        ...(compositePriceWithComponentsWithCoupons._price!.price_components as Price)[1]!,
+        _coupons: [lowFixedCashbackCoupon],
+      },
+    ],
+  },
+}

--- a/src/__tests__/fixtures/price.samples.ts
+++ b/src/__tests__/fixtures/price.samples.ts
@@ -11,7 +11,6 @@ import {
 import {
   fixedCashbackCoupon,
   fixedDiscountCoupon,
-  lowFixedCashbackCoupon,
   highFixedDiscountCoupon,
   highPercentageDiscountCoupon,
   percentage10DiscountCoupon,
@@ -3395,7 +3394,7 @@ export const compositePriceCashbackCombinedWithComponentCashbacks: CompositePric
       },
       {
         ...(compositePriceWithComponentsWithCoupons._price!.price_components as Price)[1]!,
-        _coupons: [lowFixedCashbackCoupon],
+        _coupons: [fixedCashbackCoupon],
       },
     ],
   },

--- a/src/pricing.test.ts
+++ b/src/pricing.test.ts
@@ -763,18 +763,43 @@ describe('computeAggregatedAndPriceTotals', () => {
 
     it('should compute fixed cashbacks correctly when applied at the composite price level + component level with the same cashback period', () => {
       const result = computeAggregatedAndPriceTotals([samples.compositePriceCashbackCombinedWithComponentCashbacks]);
-      console.log("combined result", JSON.stringify(result, null, 2));
-      expect(result).toBeDefined();
+      const computedPriceItem = result.items?.[0] as CompositePriceItem
+      expect(computedPriceItem?._coupons).toEqual([samples.compositePriceCashbackCombinedWithComponentCashbacks._coupons?.[0]]);
+      expect(computedPriceItem?.cashback_amount).toEqual(1000);
+      expect(computedPriceItem?.cashback_amount_decimal).toEqual('10');
+      expect(computedPriceItem?.after_cashback_amount_total).toEqual(10000);
+      expect(computedPriceItem?.after_cashback_amount_total_decimal).toEqual('100');
+      expect(computedPriceItem?.item_components?.[1].cashback_amount).toEqual(1000);
+      expect(computedPriceItem?.item_components?.[1].cashback_amount_decimal).toEqual('10');
+      expect(computedPriceItem?.item_components?.[1].after_cashback_amount_total).toEqual(9981);
+      expect(computedPriceItem?.item_components?.[1].after_cashback_amount_total_decimal).toEqual('99.807692307692');
+      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.length).toEqual(1)
+      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[0].cashback_period).toEqual('12')
+      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[0].amount_total).toEqual(2000)
     });
 
-    // WIP
-    // it('should compute fixed cashbacks correctly when applied at the composite price level + component level with different cashback periods', () => {
-    //   const result = computeAggregatedAndPriceTotals([samples.compositePriceCashbackCombinedWithComponentCashbacks]);
-    //   expect(result).toBeDefined();
-    // });
-    // // percantage + fixed
-    // // discounts should be ignored
-    // // multiple cashbacks in the composite level. TODO.
+    it.only('should compute fixed cashbacks correctly when applied at the composite price level + component level with different cashback periods', () => {
+      const priceItems = [{
+        ...samples.compositePriceCashbackCombinedWithComponentCashbacks,
+        _coupons: [coupons.lowFixedCashbackCoupon],
+      }]
+      const result = computeAggregatedAndPriceTotals(priceItems);
+      const computedPriceItem = result.items?.[0] as CompositePriceItem
+      expect(computedPriceItem?._coupons).toEqual(priceItems[0]._coupons);
+      expect(computedPriceItem?.cashback_amount).toEqual(500)
+      expect(computedPriceItem?.cashback_amount_decimal).toEqual('5')
+      expect(computedPriceItem?.after_cashback_amount_total).toEqual(10500)
+      expect(computedPriceItem?.after_cashback_amount_total_decimal).toEqual('105')
+      expect(computedPriceItem?.item_components?.[1].cashback_amount).toEqual(1000)
+      expect(computedPriceItem?.item_components?.[1].cashback_amount_decimal).toEqual('10')
+      expect(computedPriceItem?.item_components?.[1].after_cashback_amount_total).toEqual(9981)
+      expect(computedPriceItem?.item_components?.[1].after_cashback_amount_total_decimal).toEqual('99.807692307692')
+      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.length).toEqual(2)
+      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[0].cashback_period).toEqual('0')
+      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[0].amount_total).toEqual(1000)
+      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[1].cashback_period).toEqual('12')
+      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[1].amount_total).toEqual(500)
+    });
 
     it('should deliver the same result when recomputing the pricing details with discount coupons', () => {
       const result = computeAggregatedAndPriceTotals([samples.priceItemWithPercentageDiscount]);

--- a/src/pricing.test.ts
+++ b/src/pricing.test.ts
@@ -801,6 +801,8 @@ describe('computeAggregatedAndPriceTotals', () => {
       expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[1].amount_total).toEqual(500)
     });
 
+    // TODO: add tests for requires_promo_code
+
     it('should deliver the same result when recomputing the pricing details with discount coupons', () => {
       const result = computeAggregatedAndPriceTotals([samples.priceItemWithPercentageDiscount]);
       const resultRecomputed = computeAggregatedAndPriceTotals(result.items as PriceItemsDto);

--- a/src/pricing.test.ts
+++ b/src/pricing.test.ts
@@ -778,7 +778,7 @@ describe('computeAggregatedAndPriceTotals', () => {
       expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[0].amount_total).toEqual(2000)
     });
 
-    it.only('should compute fixed cashbacks correctly when applied at the composite price level + component level with different cashback periods', () => {
+    it('should compute fixed cashbacks correctly when applied at the composite price level + component level with different cashback periods', () => {
       const priceItems = [{
         ...samples.compositePriceCashbackCombinedWithComponentCashbacks,
         _coupons: [coupons.lowFixedCashbackCoupon],
@@ -795,9 +795,9 @@ describe('computeAggregatedAndPriceTotals', () => {
       expect(computedPriceItem?.item_components?.[1].after_cashback_amount_total).toEqual(9981)
       expect(computedPriceItem?.item_components?.[1].after_cashback_amount_total_decimal).toEqual('99.807692307692')
       expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.length).toEqual(2)
-      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[0].cashback_period).toEqual('0')
+      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[0].cashback_period).toEqual('12')
       expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[0].amount_total).toEqual(1000)
-      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[1].cashback_period).toEqual('12')
+      expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[1].cashback_period).toEqual('0')
       expect(computedPriceItem?.total_details?.breakdown?.cashbacks?.[1].amount_total).toEqual(500)
     });
 

--- a/src/pricing.test.ts
+++ b/src/pricing.test.ts
@@ -14,7 +14,7 @@ import {
   mapToProductSnapshot,
 } from './pricing';
 import type {
-  CompositePrice,
+  CompositePriceItem,
   CompositePriceItemDto,
   Price,
   PriceItemDto,
@@ -24,7 +24,7 @@ import type {
 } from './types';
 import { getTaxValue } from './utils';
 import { taxRateless } from './__tests__/fixtures/tax.samples';
-import { CompositePriceItemWithCashbacks } from '@epilot/pricing-client';
+import { CompositePrice } from '@epilot/pricing-client';
 
 describe('computeAggregatedAndPriceTotals', () => {
   describe('when is_composite_price = false', () => {
@@ -725,7 +725,7 @@ describe('computeAggregatedAndPriceTotals', () => {
 
     it('should compute fixed cashbacks correctly when applied at the composite price level', () => {
       const result = computeAggregatedAndPriceTotals([samples.compositePriceWithFixedCashbackCoupon]);
-      const computedPriceItem = result.items?.[0] as CompositePriceItemWithCashbacks
+      const computedPriceItem = result.items?.[0] as CompositePriceItem
       expect(computedPriceItem?._coupons).toEqual([{
         ...samples.compositePriceWithFixedCashbackCoupon._coupons?.[0]!,
         cashback_amount: 1000,
@@ -757,7 +757,7 @@ describe('computeAggregatedAndPriceTotals', () => {
         },
       ]
       const result = computeAggregatedAndPriceTotals(priceItems);
-      const computedPriceItem = result.items?.[0] as CompositePriceItemWithCashbacks
+      const computedPriceItem = result.items?.[0] as CompositePriceItem
       expect(computedPriceItem?._coupons).toEqual([
         {
           ...priceItems[0]!._coupons?.[0]!,
@@ -797,7 +797,7 @@ describe('computeAggregatedAndPriceTotals', () => {
         },
       ]
       const result = computeAggregatedAndPriceTotals(priceItems);
-      const computedPriceItem = result.items?.[0] as CompositePriceItemWithCashbacks
+      const computedPriceItem = result.items?.[0] as CompositePriceItem
       expect(computedPriceItem?._coupons).toEqual([
         {
           ...priceItems[0]!._coupons?.[0]!,
@@ -825,7 +825,7 @@ describe('computeAggregatedAndPriceTotals', () => {
 
     it('should compute percentage cashbacks correctly when applied at the composite price level', () => {
       const result = computeAggregatedAndPriceTotals([samples.compositePriceWithPercentageCashbackCoupon]);
-      const computedPriceItem = result.items?.[0] as CompositePriceItemWithCashbacks
+      const computedPriceItem = result.items?.[0] as CompositePriceItem
       expect(computedPriceItem?._coupons).toEqual([{
         ...samples.compositePriceWithPercentageCashbackCoupon._coupons?.[0]!,
         cashback_amount: 1100,
@@ -851,7 +851,7 @@ describe('computeAggregatedAndPriceTotals', () => {
 
     it('should compute fixed cashbacks correctly when applied at the composite price level + component level with the same cashback period', () => {
       const result = computeAggregatedAndPriceTotals([samples.compositePriceCashbackCombinedWithComponentCashbacks]);
-      const computedPriceItem = result.items?.[0] as CompositePriceItemWithCashbacks
+      const computedPriceItem = result.items?.[0] as CompositePriceItem
       expect(computedPriceItem?._coupons).toEqual([{
         ...samples.compositePriceCashbackCombinedWithComponentCashbacks._coupons?.[0]!,
         cashback_amount: 1000,
@@ -879,7 +879,7 @@ describe('computeAggregatedAndPriceTotals', () => {
         _coupons: [coupons.lowFixedCashbackCoupon],
       }]
       const result = computeAggregatedAndPriceTotals(priceItems);
-      const computedPriceItem = result.items?.[0] as CompositePriceItemWithCashbacks
+      const computedPriceItem = result.items?.[0] as CompositePriceItem
       expect(computedPriceItem?._coupons).toEqual([{
         ...priceItems[0]!._coupons?.[0]!,
         cashback_amount: 500,

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -9,6 +9,7 @@ import {
 } from './normalizers';
 import type {
   CashbackAmount,
+  CashbackTotals,
   CompositePriceItem,
   CompositePriceItemDto,
   Coupon,
@@ -857,7 +858,7 @@ const computeCompositePriceCashbacks = (
 
   // Convert totals to the desired precision
   // TODO: use pricing-client types once available
-  const cashback_totals: Record<string, { cashback_amount: number; cashback_amount_decimal: string }> = {};
+  const cashback_totals: CashbackTotals = {};
   for (const period in cashbackTotals) {
     const totalAmount = cashbackTotals[period];
     const convertedValues = convertCashbackAmountsPrecision(totalAmount.getAmount(), undefined, 2);

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -800,15 +800,11 @@ const computeCompositePriceCashbacks = (
   // Extract cashback coupons from the composite price item
   const appliedCashbackCoupons = getAppliedCompositeCashbackCoupons(compositePriceItem, redeemedPromos);
 
-  if (!appliedCashbackCoupons?.length) {
-    return {};
-  }
-
   const cashbackTotals: Record<string, Dinero> = {};
   const appliedCashbacksWithAmounts: Coupon[] = [];
   const cashbacks = [...(itemBreakdown.total_details?.breakdown?.cashbacks ?? [])];
 
-  for (const cashbackCoupon of appliedCashbackCoupons) {
+  for (const cashbackCoupon of appliedCashbackCoupons ?? []) {
     let unitCashbackAmount: Dinero | undefined;
 
     if (isFixedValueCoupon(cashbackCoupon)) {
@@ -857,7 +853,6 @@ const computeCompositePriceCashbacks = (
   }
 
   // Convert totals to the desired precision
-  // TODO: use pricing-client types once available
   const cashback_totals: CashbackTotals = {};
   for (const period in cashbackTotals) {
     const totalAmount = cashbackTotals[period];
@@ -882,7 +877,7 @@ const computeCompositePriceCashbacks = (
     },
     cashbacksMetadata: {
       ...(Object.keys(cashback_totals).length > 0 && { cashback_totals }),
-      ...(appliedCashbacksWithAmounts.length > 0 && { _coupons: appliedCashbacksWithAmounts }),
+      ...(appliedCashbackCoupons && { _coupons: appliedCashbacksWithAmounts }),
     },
   };
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,10 +10,9 @@ export type {
   Tax,
   TaxAmountDto,
   TaxAmount,
-  CompositePrice,
   CompositePriceItemDto,
-  CompositePriceItem,
   EntityItem,
+  CompositePrice,
   TaxAmountBreakdown,
   RecurrenceAmount,
   RecurrenceAmountWithTax,
@@ -30,6 +29,12 @@ export type {
   CashbackAmount,
   RedeemedPromo,
 } from '@epilot/pricing-client';
-import type { BillingPeriod } from '@epilot/pricing-client';
+import type { BillingPeriod, CompositePriceItem as BaseCompositePriceItem } from '@epilot/pricing-client';
 
 export type TimeFrequency = Exclude<BillingPeriod, 'one_time'>;
+
+// TODO: Remove this once the pricing-client is updated
+export type CashbackTotals = Record<string, { cashback_amount: number; cashback_amount_decimal: string }>;
+export type CompositePriceItem = BaseCompositePriceItem & {
+  cashback_totals?: CashbackTotals;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -110,7 +110,7 @@ export const getQuantityForTier = ({ min, max, quantity }: { min?: number; max: 
   return toDinero(quantity.toString(), DEFAULT_CURRENCY).subtract(toDinero(min.toString(), DEFAULT_CURRENCY)).toUnit();
 };
 
-const clamp = (value: number, minimum: number, maximum: number) => Math.min(Math.max(value, minimum), maximum);
+export const clamp = (value: number, minimum: number, maximum: number) => Math.min(Math.max(value, minimum), maximum);
 
 export const computePerUnitPriceItemValues = ({
   unitAmountDecimal,


### PR DESCRIPTION
- Added tests for fixed and percentage cashback calculations at the composite price level.
- Updated `computeAggregatedAndPriceTotals` to handle cashback coupons more effectively.
- Introduced new utility functions for calculating cashback amounts with precision.
- Added new sample coupons for testing cashback scenarios.
- Refactored existing code to improve clarity and maintainability.