### PR TITLE
feat: add removeTrailingDecimalZeros function and related tests

### DIFF
--- a/src/exports.test.ts
+++ b/src/exports.test.ts
@@ -34,6 +34,7 @@ const expectedNamedExports = [
   'extractGetAgConfig',
   'getAmountWithTax',
   'getTaxValue',
+  'removeTrailingDecimalZeros',
 ];
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {
   formatAmountFromString,
   formatPriceUnit,
   parseDecimalValue,
+  removeTrailingDecimalZeros,
   toIntegerAmount,
   addSeparatorToDineroString,
 } from './money/formatters';


### PR DESCRIPTION
- Implemented removeTrailingDecimalZeros function to clean up decimal strings by removing trailing double zeros while preserving suffixes.
- Updated exports to include the new function and added comprehensive unit tests to validate its behavior across various scenarios.