### PR TITLE
fix: retain raw numeric value for line item unit_amount_net

### DIFF
--- a/.changeset/thirty-jokes-notice.md
+++ b/.changeset/thirty-jokes-notice.md
@@ -1,0 +1,5 @@
+---
+'@epilot/pricing': patch
+---
+
+Updated the processOrderTableData function to ensure that the line item unit_amount_net remains a raw numeric value, while the formatted value is still accessible under price.unit_amount_net.

--- a/src/variables/index.test.ts
+++ b/src/variables/index.test.ts
@@ -98,6 +98,19 @@ describe('processOrderTableData', () => {
     expect(result.total_details.recurrences).toEqual(orderWithCompositeItemResults.total_details.recurrences);
   });
 
+  it('leaves the line item unit_amount_net as a raw numeric value (mirroring unit_amount_gross)', async () => {
+    const result = await processOrderTableData(orderWithCompositeItem as any, mockI18n);
+
+    const item = result.products[7];
+
+    // The line item keeps the raw numeric net amount, it is NOT overwritten with a formatted string.
+    expect(item.unit_amount_net).toBe(65000);
+    expect(typeof item.unit_amount_net).toBe('number');
+
+    // The formatted value is still exposed under price.unit_amount_net for templates that render it.
+    expect(item.price.unit_amount_net).toBe('650,00\xa0€');
+  });
+
   it('returns correctly the tax details', async () => {
     const result = await processOrderTableData(orderWithMultiplePrices as any, mockI18n);
     expect(result.total_details.recurrences).toEqual(orderWithMultiplePricesResults.total_details.recurrences);

--- a/src/variables/process-order-table-data.ts
+++ b/src/variables/process-order-table-data.ts
@@ -406,7 +406,6 @@ export const processOrderTableData = (data: any, i18n: I18n) => {
         item.total_details.breakdown.recurrences = recurrences;
       }
 
-      item.unit_amount_net = unitAmountNetFormatted;
       item.unit_amount = unitAmountFormatted;
       item.amount_subtotal = unitAmountSubtotalFormatted;
       item.amount_tax = amountTaxFormatted;
@@ -450,7 +449,7 @@ export const processOrderTableData = (data: any, i18n: I18n) => {
       const quantityDisplayValue = !isCoupon ? getQuantity(item, item.parent_item) : undefined;
 
       const unitAmountDisplayValue = isUnitAmountApproved ? originalUnitAmountFormatted : item.unit_amount;
-      const unitAmountNetDisplayValue = isUnitAmountApproved ? originalUnitAmountNetFormatted : item.unit_amount_net;
+      const unitAmountNetDisplayValue = isUnitAmountApproved ? originalUnitAmountNetFormatted : unitAmountNetFormatted;
       delete item.parent_item;
 
       // build custom variable


### PR DESCRIPTION
Updated the processOrderTableData function to ensure that the line item unit_amount_net remains a raw numeric value, while the formatted value is still accessible under price.unit_amount_net. Added a corresponding test to verify this behavior.